### PR TITLE
Suggestion of rewrite for MLJBase.matrix

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,3 +1,5 @@
+# This file is machine-generated - editing it directly is not advised
+
 [[Arpack]]
 deps = ["BinaryProvider", "Libdl", "LinearAlgebra", "Random", "SparseArrays", "Test"]
 git-tree-sha1 = "1ce1ce9984683f0b6a587d5bdbc688ecb480096f"
@@ -70,7 +72,7 @@ deps = ["Mmap"]
 uuid = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 
 [[Distributed]]
-deps = ["LinearAlgebra", "Random", "Serialization", "Sockets"]
+deps = ["Random", "Serialization", "Sockets"]
 uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 
 [[Distributions]]
@@ -96,7 +98,7 @@ deps = ["Random"]
 uuid = "9fa8497b-333b-5362-9e8d-4d0656e87820"
 
 [[InteractiveUtils]]
-deps = ["LinearAlgebra", "Markdown"]
+deps = ["Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 
 [[IterableTables]]
@@ -259,7 +261,7 @@ uuid = "4c63d2b9-4356-54db-8cca-17b64c39e42c"
 version = "0.7.0"
 
 [[SuiteSparse]]
-deps = ["Libdl", "LinearAlgebra", "SparseArrays"]
+deps = ["Libdl", "LinearAlgebra", "Serialization", "SparseArrays"]
 uuid = "4607b0f0-06f3-5cda-b6b1-a6196a1729e9"
 
 [[TableShowUtils]]
@@ -303,7 +305,7 @@ uuid = "30578b45-9adc-5946-b283-645ec420af67"
 version = "0.4.0"
 
 [[UUIDs]]
-deps = ["Random"]
+deps = ["Random", "SHA"]
 uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [[Unicode]]

--- a/Project.toml
+++ b/Project.toml
@@ -10,6 +10,7 @@ Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 Query = "1a8c2f83-1ff3-5112-b086-8aa67b057ba1"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 TableTraits = "3783bdb8-4a98-5b6b-af9a-565f29a5fe9c"
+Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/MLJBase.jl
+++ b/src/MLJBase.jl
@@ -1,12 +1,12 @@
 # Users of this module should first read the document
-# https://github.com/alan-turing-institute/MLJ.jl/blob/master/doc/adding_new_models.md 
+# https://github.com/alan-turing-institute/MLJ.jl/blob/master/doc/adding_new_models.md
 
 module MLJBase
 
 export MLJType, Model, Supervised, Unsupervised, Deterministic, Probabilistic
 export Rows, Cols, Schema, retrieve, getrows
 export fit, update, clean!, info, coerce
-export predict, predict_mean, predict_mode 
+export predict, predict_mean, predict_mode
 export transform, inverse_transform, se, evaluate, best
 export target_kind, target_quantity, inputs_can_be, is_pure_julia
 export package_url, package_name, package_uuid
@@ -20,6 +20,7 @@ export pdf, mean, mode
 import Base.==
 using Query
 import TableTraits
+import Tables
 import DataFrames                # TODO: get rid of this dependency
 import Distributions
 import Distributions: pdf, mode
@@ -57,7 +58,7 @@ abstract type Probabilistic{R} <: Supervised{R} end
 abstract type Deterministic{R} <: Supervised{R} end
 
 # for displaying objects of `MLJType`:
-include("show.jl") 
+include("show.jl")
 
 # probability distributions and methods not provided by
 # Distributions.jl package:
@@ -123,7 +124,7 @@ coerce(model::Model, Xtable) = Xtable
 # then users will not be able to use MLJ's performant `EnsembleModel`
 # on `model` unless one overloads the following method for type
 # `TABLE`:
-getrows(model::Model, X, r) = retrieve(X, Rows, r)   
+getrows(model::Model, X, r) = retrieve(X, Rows, r)
 # here `r` is any integer, unitrange or colon `:`, and the right-hand
 # side defined in `data.jl`.
 
@@ -158,7 +159,7 @@ function info(modeltype::Type{<:Model})
         target_quantity(modeltype) in [:univariate, :multivariate] ||
             error(message*"target_quantity must return :univariate or :multivariate")
     end
-    
+
     issubset(Set(inputs_can_be(modeltype)), Set([:numeric, :nominal, :missing])) ||
         error(message*"inputs_can_be must return a vector with entries from [:numeric, :nominal, :missing]")
     is_pure_julia(modeltype) in [:yes, :no, :unknown] ||
@@ -180,7 +181,7 @@ function info(modeltype::Type{<:Model})
     if modeltype <: Supervised
         d[:target_is] = target_is(modeltype)
     end
-    
+
     return d
 end
 info(model::Supervised) = info(typeof(model))

--- a/src/data.jl
+++ b/src/data.jl
@@ -99,7 +99,7 @@ Convert a table source `X` into an `Matrix`; or, if `X` is a `Matrix`,
 return `X`.
 """
 function matrix(X; vardim=1)
-    Tables.istable(X) || error("Argument is not an iterable table.")
+    Tables.istable(X) || error("Argument is not an table.")
 
     # see also https://github.com/JuliaData/Tables.jl/issues/58
     M = convert(Matrix, Tables.columns(X))

--- a/src/data.jl
+++ b/src/data.jl
@@ -104,7 +104,7 @@ function matrix(X; vardim=1)
     # see also https://github.com/JuliaData/Tables.jl/issues/58
     M = convert(Matrix, Tables.columns(X))
     vardim == 1 && return M
-    return copy(permutedims(M))
+    return permutedims(M)
 end
 
 matrix(X::Matrix) = X

--- a/test/data.jl
+++ b/test/data.jl
@@ -18,7 +18,9 @@ decoder = MLJBase.CategoricalDecoder(X, eltype=Float16)
 decoder = MLJBase.CategoricalDecoder(X)
 @test inverse_transform(decoder, transform(decoder, Xsmall)) == Xsmall
 
-@test MLJBase.matrix(DataFrame(A)) == A
+dfA = DataFrame(A)
+@test MLJBase.matrix(dfA) == A
+@test MLJBase.matrix(dfA, vardim=2) == permutedims(A)
 
 df = DataFrame(A)
 df.z  =1:10


### PR DESCRIPTION
This is a suggestion of rewrite for `MLJBase.matrix`.

This (or better) may be natively supported by `Tables.jl` though depending on the outcome of [this issue](https://github.com/JuliaData/Tables.jl/issues/58) I opened there.

Ideally `Tables` would support something like that, next best would be that MLJBase supports it. 

Either way, I'll need to open PRs to remove the calls to `copy(transpose...)` in interfaces which would not be needed anymore.

PS: there's also discussion to have algorithms such as `kmeans` from `Clustering.jl` directly support the `Table` type but we're not there yet so this would be a good temporary fix.