### PR TITLE
Fix dataframe deprecation warning

### DIFF
--- a/src/datasets.jl
+++ b/src/datasets.jl
@@ -21,7 +21,7 @@ having six numerical and six categorical features."""
 function load_reduced_ames()
     df = CSV.read(joinpath(datadir, "reduced_ames.csv"), copycols=true,
                   categorical=true)
-    df[:target] = exp.(df[:target])
+    df[!, :target] = exp.(df[:target])
     # TODO: uncomment following after julia #29501 is resolved
 #    df.OverallQual = categorical(df.OverallQual, ordered=true)
 #    df[:GarageCars] = categorical(df[:GarageCars], ordered=true)
@@ -36,7 +36,7 @@ end
 function load_ames()
     df = CSV.read(joinpath(datadir, "ames.csv"), copycols=true,
                   categorical=true)
-    df[:target] = exp.(df[:target])
+    df[!, :target] = exp.(df[:target])
     return SupervisedTask(verbosity=0, data=df,
                           target=:target,
                           ignore=[:Id,],

--- a/src/datasets.jl
+++ b/src/datasets.jl
@@ -21,7 +21,7 @@ having six numerical and six categorical features."""
 function load_reduced_ames()
     df = CSV.read(joinpath(datadir, "reduced_ames.csv"), copycols=true,
                   categorical=true)
-    df[!, :target] = exp.(df[:target])
+    df[!, :target] .= exp.(df[!, :target])
     # TODO: uncomment following after julia #29501 is resolved
 #    df.OverallQual = categorical(df.OverallQual, ordered=true)
 #    df[:GarageCars] = categorical(df[:GarageCars], ordered=true)
@@ -36,7 +36,7 @@ end
 function load_ames()
     df = CSV.read(joinpath(datadir, "ames.csv"), copycols=true,
                   categorical=true)
-    df[!, :target] = exp.(df[:target])
+    df[!, :target] .= exp.(df[!, :target])
     return SupervisedTask(verbosity=0, data=df,
                           target=:target,
                           ignore=[:Id,],


### PR DESCRIPTION
Corresponds to a message on slack,

```
task = load_reduced_ames();
┌ Warning: getindex(df::DataFrame, col_ind::ColumnIndex) is deprecated, use df[!, col_ind] instead.
│   caller = load_reduced_ames() at datasets.jl:18
└ @ MLJBase ~/.julia/packages/MLJBase/vdhww/src/datasets.jl:18
```

This is due to the update https://discourse.julialang.org/t/release-announcements-for-dataframes-jl/18258/38 

PS: this only makes sense along with a compat requirement to have DataFrames be `>=0.19.0` otherwise it will error; so this should be merged when we're happy to use the latest DataFrames (currently clashes with requirements from us to have Categorical Arrays to be of a specific version)