### PR TITLE
Lots of little improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ julia:
 #  - 0.7
   - 1.0
   - 1.1
+  - 1.2
   - nightly
 notifications:
   email: false

--- a/Project.toml
+++ b/Project.toml
@@ -27,8 +27,9 @@ julia = "1"
 [extras]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+LossFunctions = "30fc2ffe-d236-52d8-8643-a9d8f7c094a7"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TypedTables = "9d95f2ec-7b3d-5a63-8d20-e2491e220bb9"
 
 [targets]
-test = ["CSV", "DataFrames", "Test", "TypedTables"]
+test = ["CSV", "DataFrames", "LossFunctions", "Test", "TypedTables"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MLJBase"
 uuid = "a7f614a8-145f-11e9-1d2a-a57a1082229d"
 authors = ["Anthony D. Blaom <anthony.blaom@gmail.com>"]
-version = "0.4.0"
+version = "0.5.0"
 
 [deps]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"

--- a/Project.toml
+++ b/Project.toml
@@ -20,7 +20,7 @@ Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 CSV = "0.5"
 CategoricalArrays = "<0.5.3"
 Requires = "^0.5.2"
-ScientificTypes = "0.1.3"
+ScientificTypes = "0.2.0"
 Tables = "<0.1.19, >= 0.2"
 julia = "1"
 

--- a/src/MLJBase.jl
+++ b/src/MLJBase.jl
@@ -149,7 +149,8 @@ const ALL_TRAITS = [:input_scitype, :output_scitype, :target_scitype,
                     :load_path, :package_uuid, 
                     :package_url, :is_wrapper, :supports_weights, :docstring,
                     :name, :is_supervised, :prediction_type,
-                    :implemented_methods]
+                    :implemented_methods, :hyperparameters,
+                    :hyperparameter_types]
 const SUPERVISED_TRAITS = filter(ALL_TRAITS) do trait
     !(trait in [:output_scitype,])
 end
@@ -182,6 +183,10 @@ prediction_type(::Type{<:Deterministic}) = :deterministic
 prediction_type(::Type{<:Probabilistic}) = :probabilistic
 prediction_type(::Type{<:Interval}) = :interval
 implemented_methods(M::Type{<:MLJType}) = map(f->f.name, methodswith(M))
+hyperparameters(M::Type) = collect(fieldnames(M))
+hyperparameter_types(M::Type) =
+    [Meta.parse(string(T)) for T in fieldtypes(M)]
+
 
 # declare `trait(object) = trait(typeof(object))`:      
 for trait in ALL_TRAITS

--- a/src/MLJBase.jl
+++ b/src/MLJBase.jl
@@ -8,7 +8,7 @@ export DeterministicNetwork, ProbabilisticNetwork, UnsupervisedNetwork
 export fit, update, clean!
 export predict, predict_mean, predict_mode, fitted_params
 export transform, inverse_transform, se, evaluate, best
-export traits
+export info
 
 export load_path, package_url, package_name, package_uuid  # model_traits.jl
 export input_scitype, supports_weights                     # model_traits.jl
@@ -44,6 +44,10 @@ export Scientific, Found, Unknown, Finite, Infinite
 export OrderedFactor, Multiclass, Count, Continuous
 export Binary, ColorImage, GrayImage, Image
 export scitype, scitype_union, coerce, schema
+
+# rexport from Random, Statistics, Distributions, CategoricalArrays:
+export pdf, mode, median, mean, shuffle!, categorical, shuffle, levels, levels!
+export std
 
 import Base.==
 
@@ -167,12 +171,12 @@ clean!(model::Model) = ""
 
 """ 
 
-    traits(object)
+    info(object)
 
 List the traits of an object, such as a model or a performance measure.
 
 """
-traits(object) = traits(object, Val(ScientificTypes.trait(object))) 
+info(object) = info(object, Val(ScientificTypes.trait(object))) 
 
 
 include("model_traits.jl")

--- a/src/MLJBase.jl
+++ b/src/MLJBase.jl
@@ -12,7 +12,8 @@ export transform, inverse_transform, se, evaluate, best
 export load_path, package_url, package_name, package_uuid
 export input_scitype, supports_weights
 export target_scitype, output_scitype
-export is_pure_julia, is_wrapper, prediction_type                              
+export is_pure_julia, is_wrapper, prediction_type
+export traits
 
 export params                                        # parameters.jl
 export reconstruct, int, decoder, classes            # data.jl
@@ -133,78 +134,6 @@ function inverse_transform end
 # fitted parameters (eg, coeficients of linear model):
 fitted_params(::Model, fitresult) = (fitresult=fitresult,)
 
-# operations implemented by some meta-models:
-function se end
-function evaluate end
-function best end
-
-# a model wishing invalid hyperparameters to be corrected with a
-# warning should overload this method (return value is the warning
-# message):
-clean!(model::Model) = ""
-
-# model trait names:
-const ALL_TRAITS = [:input_scitype, :output_scitype, :target_scitype,
-                    :is_pure_julia, :package_name, :package_license,
-                    :load_path, :package_uuid, 
-                    :package_url, :is_wrapper, :supports_weights, :docstring,
-                    :name, :is_supervised, :prediction_type,
-                    :implemented_methods, :hyperparameters,
-                    :hyperparameter_types]
-const SUPERVISED_TRAITS = filter(ALL_TRAITS) do trait
-    !(trait in [:output_scitype,])
-end
-const UNSUPERVISED_TRAITS = filter(ALL_TRAITS) do trait
-    !(trait in [:target_scitype, :prediction_type, :supports_weights])
-end
-
-# fallback trait declarations:
-input_scitype(::Type) = Unknown
-output_scitype(::Type) = Unknown
-target_scitype(::Type) = Unknown  # used for measures too
-is_pure_julia(::Type) = missing
-package_name(::Type) = "unknown"
-package_license(::Type) = "unknown"
-load_path(::Type) = "unknown"
-package_uuid(::Type) = "unknown"
-package_url(::Type) = "unknown"
-is_wrapper(::Type) = false
-supports_weights(::Type) = false  # used for measures too
-docstring(object::Type{<:MLJType}) =
-    "$(name(object)) from $(package_name(object)).jl.\n"*
-"[Documentation]($(package_url(object)))."
-
-# "derived" traits:
-name(M::Type{<:MLJType}) = split(string(coretype(M)), '.')[end] |> String
-is_supervised(::Type{<:Type}) = false
-is_supervised(::Type{<:Supervised}) = true
-prediction_type(::Type) = :unknown # used for measures too
-prediction_type(::Type{<:Deterministic}) = :deterministic
-prediction_type(::Type{<:Probabilistic}) = :probabilistic
-prediction_type(::Type{<:Interval}) = :interval
-implemented_methods(M::Type{<:MLJType}) = map(f->f.name, methodswith(M))
-hyperparameters(M::Type) = collect(fieldnames(M))
-hyperparameter_types(M::Type) =
-    [Meta.parse(string(T)) for T in fieldtypes(M)]
-# function hyperparmeter_defaults(M::Type)
-#     try
-#         model = M()
-#         return [Meta.parse(string(getproperty(model, fld)))
-#                 for fld in fieldnames(M)]
-#     catch
-#         return []
-#     end
-# end
-                    
-
-# declare `trait(object) = trait(typeof(object))`:      
-for trait in ALL_TRAITS
-    eval(quote
-        $trait(object) = $trait(typeof(object))
-    end)
-end
-
-
 # probabilistic supervised models may also overload one or more of
 # `predict_mode`, `predict_median` and `predict_mean` defined below.
 
@@ -219,6 +148,32 @@ predict_mean(model::Probabilistic, fitresult, Xnew) =
 # median:
 predict_median(model::Probabilistic, fitresult, Xnew) =
     median.(predict(model, fitresult, Xnew))
+
+# operations implemented by some meta-models:
+function se end
+function evaluate end
+function best end
+
+# a model wishing invalid hyperparameters to be corrected with a
+# warning should overload this method (return value is the warning
+# message):
+clean!(model::Model) = ""
+
+
+## TRAITS
+
+""" 
+
+    traits(object)
+
+List the traits of an object, such as a model or a performance measure.
+
+"""
+traits(object) = traits(object, Val(ScientificTypes.trait(object))) 
+
+
+include("model_traits.jl")
+
 
 # for unpacking the fields of MLJ objects:
 include("parameters.jl")

--- a/src/MLJBase.jl
+++ b/src/MLJBase.jl
@@ -1,6 +1,5 @@
 # Users of this module should first read the document
 # https://alan-turing-institute.github.io/MLJ.jl/dev/adding_models_for_general_use/
-__precompile__(false)
 module MLJBase
 
 export MLJType, Model, Supervised, Unsupervised
@@ -9,12 +8,12 @@ export DeterministicNetwork, ProbabilisticNetwork, UnsupervisedNetwork
 export fit, update, clean!
 export predict, predict_mean, predict_mode, fitted_params
 export transform, inverse_transform, se, evaluate, best
-export load_path, package_url, package_name, package_uuid
-export input_scitype, supports_weights
-export target_scitype, output_scitype
-export is_pure_julia, is_wrapper, prediction_type
 export traits
 
+export load_path, package_url, package_name, package_uuid  # model_traits.jl
+export input_scitype, supports_weights                     # model_traits.jl
+export target_scitype, output_scitype                      # model_traits.jl
+export is_pure_julia, is_wrapper, prediction_type          # model_traits.jl
 export params                                        # parameters.jl
 export reconstruct, int, decoder, classes            # data.jl
 export selectrows, selectcols, select, nrows         # data.jl
@@ -30,7 +29,11 @@ export info                                          # info.jl
 export @load_boston, @load_ames, @load_iris          # datasets.jl
 export @load_reduced_ames                            # datasets.jl
 export @load_crabs                                   # datasets.jl
-
+export orientation, reports_each_observation         # measures.jl
+export is_feature_dependent                          # measures.jl
+export mav, mae, rms, rmsl, rmslp1, rmsp, l1, l2     # measures.jl
+export misclassification_rate, cross_entropy         # measures.jl
+export default_measure                               # measures.jl
 
 # methods from other packages to be rexported:
 export pdf, mean, mode
@@ -174,7 +177,6 @@ traits(object) = traits(object, Val(ScientificTypes.trait(object)))
 
 include("model_traits.jl")
 
-
 # for unpacking the fields of MLJ objects:
 include("parameters.jl")
 
@@ -191,6 +193,7 @@ include("distributions.jl")
 include("info.jl")
 include("datasets.jl") # importing CSV will also load datasets_requires.jl
 include("tasks.jl")
+include("measures.jl")
 
 # __init__() function:
 include("init.jl")

--- a/src/MLJBase.jl
+++ b/src/MLJBase.jl
@@ -26,6 +26,10 @@ export UnivariateFinite, average                     # distributions.jl
 export SupervisedTask, UnsupervisedTask, MLJTask     # tasks.jl
 export X_and_y, X_, y_, nrows, nfeatures             # tasks.jl
 export info                                          # info.jl
+export @load_boston, @load_ames, @load_iris          # datasets.jl
+export @load_reduced_ames                            # datasets.jl
+export @load_crabs                                   # datasets.jl
+
 
 # methods from other packages to be rexported:
 export pdf, mean, mode
@@ -213,6 +217,7 @@ include("data.jl")
 include("distributions.jl")
 
 include("info.jl")
+include("datasets.jl") # importing CSV will also load datasets_requires.jl
 include("tasks.jl")
 
 # __init__() function:

--- a/src/MLJBase.jl
+++ b/src/MLJBase.jl
@@ -31,9 +31,9 @@ export @load_reduced_ames                            # datasets.jl
 export @load_crabs                                   # datasets.jl
 export orientation, reports_each_observation         # measures.jl
 export is_feature_dependent                          # measures.jl
+export default_measure, value                        # measures.jl
 export mav, mae, rms, rmsl, rmslp1, rmsp, l1, l2     # measures.jl
 export misclassification_rate, cross_entropy         # measures.jl
-export default_measure                               # measures.jl
 
 # methods from other packages to be rexported:
 export pdf, mean, mode

--- a/src/MLJBase.jl
+++ b/src/MLJBase.jl
@@ -1,6 +1,6 @@
 # Users of this module should first read the document
 # https://alan-turing-institute.github.io/MLJ.jl/dev/adding_models_for_general_use/
-
+__precompile__(false)
 module MLJBase
 
 export MLJType, Model, Supervised, Unsupervised
@@ -146,9 +146,10 @@ clean!(model::Model) = ""
 # model trait names:
 const ALL_TRAITS = [:input_scitype, :output_scitype, :target_scitype,
                     :is_pure_julia, :package_name, :package_license,
-                    :load_path, :package_uuid,
+                    :load_path, :package_uuid, 
                     :package_url, :is_wrapper, :supports_weights, :docstring,
-                    :name, :is_supervised, :prediction_type]
+                    :name, :is_supervised, :prediction_type,
+                    :implemented_methods]
 const SUPERVISED_TRAITS = filter(ALL_TRAITS) do trait
     !(trait in [:output_scitype,])
 end
@@ -180,6 +181,7 @@ prediction_type(::Type) = :unknown # used for measures too
 prediction_type(::Type{<:Deterministic}) = :deterministic
 prediction_type(::Type{<:Probabilistic}) = :probabilistic
 prediction_type(::Type{<:Interval}) = :interval
+implemented_methods(M::Type{<:MLJType}) = map(f->f.name, methodswith(M))
 
 # declare `trait(object) = trait(typeof(object))`:      
 for trait in ALL_TRAITS
@@ -187,6 +189,7 @@ for trait in ALL_TRAITS
         $trait(object) = $trait(typeof(object))
     end)
 end
+
 
 # probabilistic supervised models may also overload one or more of
 # `predict_mode`, `predict_median` and `predict_mean` defined below.

--- a/src/MLJBase.jl
+++ b/src/MLJBase.jl
@@ -186,7 +186,16 @@ implemented_methods(M::Type{<:MLJType}) = map(f->f.name, methodswith(M))
 hyperparameters(M::Type) = collect(fieldnames(M))
 hyperparameter_types(M::Type) =
     [Meta.parse(string(T)) for T in fieldtypes(M)]
-
+# function hyperparmeter_defaults(M::Type)
+#     try
+#         model = M()
+#         return [Meta.parse(string(getproperty(model, fld)))
+#                 for fld in fieldnames(M)]
+#     catch
+#         return []
+#     end
+# end
+                    
 
 # declare `trait(object) = trait(typeof(object))`:      
 for trait in ALL_TRAITS

--- a/src/MLJBase.jl
+++ b/src/MLJBase.jl
@@ -8,7 +8,7 @@ export DeterministicNetwork, ProbabilisticNetwork, UnsupervisedNetwork
 export fit, update, clean!
 export predict, predict_mean, predict_mode, fitted_params
 export transform, inverse_transform, se, evaluate, best
-export info
+export info, info_dict
 
 export load_path, package_url, package_name, package_uuid  # model_traits.jl
 export input_scitype, supports_weights                     # model_traits.jl

--- a/src/data.jl
+++ b/src/data.jl
@@ -56,9 +56,10 @@ or `false` for each column `name::Symbol` of `table`.
 Whenever a returned table contains a single column, it is converted to
 a vector unless `wrap_singles=true`.
 
-Scientific type conversions can be optionally specified:
+Scientific type conversions can be optionally specified (note
+semicolon):
 
-    unpack(table, c...; col1=>scitype1, col2=>scitype2, ... )
+    unpack(table, c...; wrap_singles=false, col1=>scitype1, col2=>scitype2, ... )
 
 ### Example
 
@@ -86,8 +87,7 @@ function unpack(X, conditionals...; wrap_singles=false, pairs...)
     if isempty(pairs)
         Xfixed = X
     else
-        fix_dict = Dict(pairs...)
-        Xfixed = ScientificTypes.coerce(fix_dict, X)
+        Xfixed = ScientificTypes.coerce(X, pairs...)
     end
 
     unpacked = Any[]

--- a/src/datasets.jl
+++ b/src/datasets.jl
@@ -1,67 +1,47 @@
-using .CSV
+# see also the non-macro versions in datasets_requires.jl
 
-export load_boston, load_ames, load_iris             # datasets.jl
-export load_reduced_ames                             # datasets.jl
-export load_crabs, datanow                           # datasets.jl
-
-datadir = joinpath(dirname(dirname(@__FILE__)), "data") # OS agnostic
-
-"""Load a well-known public regression dataset with nominal features."""
-function load_boston()
-    df = CSV.read(joinpath(datadir, "Boston.csv"), copycols=true,
-                  categorical=true)
-    return SupervisedTask(verbosity=0, data=df,
-                          target=:MedV,
-                          ignore=[:Chas,],
-                          is_probabilistic=false)
+"""Load a well-known public regression dataset with `Continuous` features."""
+macro load_boston()
+    quote
+        import CSV
+        y, X = unpack(load_boston(), ==(:MedV), x->x != :Chas)
+        (X, y)
+    end
 end
 
-"""Load a reduced version of the well-known Ames Housing task,
-having six numerical and six categorical features."""
-function load_reduced_ames()
-    df = CSV.read(joinpath(datadir, "reduced_ames.csv"), copycols=true,
-                  categorical=true)
-    # TODO: uncomment following after julia #29501 is resolved
-#    df.OverallQual = categorical(df.OverallQual, ordered=true)
-#    df[:GarageCars] = categorical(df[:GarageCars], ordered=true)
-#    df[:YearBuilt] = categorical(df[:YearBuilt], ordered=true)
-#    df[:YearRemodAdd] = categorical(df[:YearRemodAdd], ordered=true)
-    return SupervisedTask(verbosity=0, data=df,
-                          target=:target,
-                          is_probabilistic=false)
+"""Load a reduced version of the well-known Ames Housing task"""
+macro load_reduced_ames()
+    quote
+        import CSV
+        y, X = unpack(load_reduced_ames(), ==(:target), x-> true)
+        (X, y)
+    end
 end
 
 """Load the full version of the well-known Ames Housing task."""
-function load_ames()
-    df = CSV.read(joinpath(datadir, "ames.csv"), copycols=true,
-                  categorical=true)
-    return SupervisedTask(verbosity=0, data=df,
-                          target=:target,
-                          ignore=[:Id,],
-                          is_probabilistic=false)
+macro load_ames()
+    quote
+        import CSV
+        y, X = unpack(load_ames(), ==(:target), x->x != :Id)
+        (X, y)
+    end
 end
 
 """Load a well-known public classification task with nominal features."""
-function load_iris()
-    df = CSV.read(joinpath(datadir, "iris.csv"), pool=true, copycols=true,
-                  categorical=true)
-    return SupervisedTask(verbosity=0, data=df,
-                          target=:target,
-                          is_probabilistic=false)
+macro load_iris()
+    quote
+        import CSV
+        y, X = unpack(load_iris(), ==(:target), x-> true)
+        (X, y)
+    end
 end
 
 """Load a well-known crab classification dataset with nominal features."""
-function load_crabs()
-    df = CSV.read(joinpath(datadir, "crabs.csv"), pool=true, copycols=true,
-                  categorical=true)
-    return SupervisedTask(verbosity=0, data=df,
-                          target=:sp,
-                          ignore=[:sex, :index],
-                          is_probabilistic=true)
+macro load_crabs()
+    quote
+        import CSV
+        y, X = unpack(load_crabs(), ==(:sp), x-> !(x in [:sex, :index]))
+        (X, y)
+    end
 end
 
-"""Get some supervised data now!!"""
-function datanow()
-    X, y = X_and_y(load_boston())
-    return (selectrows(X, 1:75), y[1:75])
-end

--- a/src/datasets_requires.jl
+++ b/src/datasets_requires.jl
@@ -1,0 +1,32 @@
+# see also the macro versions in datasets.jl
+
+using .CSV
+
+export load_boston, load_ames, load_iris
+export load_reduced_ames               
+export load_crabs
+
+datadir = joinpath(@__DIR__, "..", "data")
+
+load_boston() = CSV.read(joinpath(datadir, "Boston.csv"), copycols=true,
+                         categorical=true)
+
+function load_reduced_ames()
+    df = CSV.read(joinpath(datadir, "reduced_ames.csv"), copycols=true,
+                  categorical=true)
+    return coerce(df, :OverallQual => OrderedFactor,
+                  :GarageCars => Count,
+                  :YearBuilt => Continuous,
+                  :YearRemodAdd => Continuous)
+end
+
+load_ames() = CSV.read(joinpath(datadir, "ames.csv"), copycols=true,
+                  categorical=true)
+
+load_iris() = CSV.read(joinpath(datadir, "iris.csv"), pool=true, copycols=true,
+                  categorical=true)
+
+load_crabs() = CSV.read(joinpath(datadir, "crabs.csv"), pool=true,
+                  copycols=true, categorical=true)
+
+

--- a/src/info.jl
+++ b/src/info.jl
@@ -12,12 +12,7 @@ function info(M::Type{<:Model}, traits)
 
     message = "$M has a bad trait declaration.\n"
 
-    load_path(M) == "unknown" &&
-        error(message*"MLJBase.load_path($M) should be defined so that "* 
-              "using MLJ; import MLJ.load_path($M) loads $M into "*
-              "current namespace.")
-
-    is_pure_julia(M) in [true, false, missing] ||
+    ismissing(is_pure_julia(M)) || is_pure_julia(M) isa Bool ||
         error(message*"is_pure_julia($M) must return true, false or missing. ")
 
     :supports_weights in traits &&

--- a/src/info.jl
+++ b/src/info.jl
@@ -4,11 +4,11 @@
 # values as a named-tuple, more friendly for user-interaction. One can
 # similarly call `traits` on performance measures.
 
-info(M::Type{<:Supervised}) = info(M, SUPERVISED_TRAITS)
-info(M::Type{<:Unsupervised}) = info(M, UNSUPERVISED_TRAITS)
-info(model::Model) = info(typeof(model))
+info_dict(M::Type{<:Supervised}) = info_dict(M, SUPERVISED_TRAITS)
+info_dict(M::Type{<:Unsupervised}) = info_dict(M, UNSUPERVISED_TRAITS)
+info_dict(model::Model) = info_dict(typeof(model))
 
-function info(M::Type{<:Model}, traits)
+function info_dict(M::Type{<:Model}, traits)
 
     message = "$M has a bad trait declaration.\n"
 

--- a/src/info.jl
+++ b/src/info.jl
@@ -1,23 +1,3 @@
-target_quantity(m) =
-    target_scitype(m) <: Tuple ? true : false
-is_probabilistic(::Type{<:Model}) = false
-is_probabilistic(::Type{<:Deterministic}) = false
-is_probabilistic(::Type{<:Probabilistic}) = true
-
-function coretype(M)
-    if isdefined(M, :name)
-        return M.name
-    else
-        return coretype(M.body)
-    end
-end
-    
-name(M::Type{<:Model}) = split(string(coretype(M)), '.')[end] |> String
-
-if VERSION < v"1.0.0"
-    import Base.info
-end
-
 function info(M::Type{<:Supervised})
 
     message = "$M has a bad trait declaration. "
@@ -30,16 +10,17 @@ function info(M::Type{<:Supervised})
 
     d = LittleDict{Symbol,Any}()
     d[:name] = name(M)
+    d[:docstring] = docstring(M)
     d[:package_name] = package_name(M)
     d[:package_url] = package_url(M)
+    d[:package_uuid] = package_uuid(M)
     d[:package_license] = package_license(M)
     d[:load_path] = load_path(M)
     d[:is_wrapper] = is_wrapper(M)
     d[:is_pure_julia] = is_pure_julia(M)
-    d[:package_uuid] = package_uuid(M)
     d[:supports_weights] = supports_weights(M)
     d[:is_supervised] = true
-    d[:is_probabilistic] = is_probabilistic(M)
+    d[:prediction_type] = prediction_type(M)
     d[:input_scitype] = input_scitype(M)
     d[:target_scitype] = target_scitype(M)
     return d
@@ -57,9 +38,11 @@ function info(M::Type{<:Unsupervised})
 
     d = LittleDict{Symbol,Any}()
     d[:name] = name(M)
+    d[:docstring] = docstring(M)
     d[:package_name] = package_name(M)
     d[:package_url] = package_url(M)
     d[:package_uuid] = package_uuid(M)
+    d[:package_license] = package_license(M)
     d[:load_path] = load_path(M)
     d[:is_wrapper] = is_wrapper(M)
     d[:is_pure_julia] = is_pure_julia(M)

--- a/src/info.jl
+++ b/src/info.jl
@@ -1,3 +1,9 @@
+# `info` returns a dictionary of model trait values suitable, after
+# encoding, to serializing to TOML file. Not intended to be exposed to
+# user. The `traits` function, defined in MLJ, returns the trait
+# values as a named-tuple, more friendly for user-interaction. One can
+# similarly call `traits` on performance measures.
+
 info(M::Type{<:Supervised}) = info(M, SUPERVISED_TRAITS)
 info(M::Type{<:Unsupervised}) = info(M, UNSUPERVISED_TRAITS)
 info(model::Model) = info(typeof(model))

--- a/src/info.jl
+++ b/src/info.jl
@@ -1,56 +1,28 @@
-function info(M::Type{<:Supervised})
-
-    message = "$M has a bad trait declaration. "
-
-    load_path != "unknown" || error(message*"MLJBase.load_path($M) should be defined so that "* 
-                                    "using MLJ; import MLJ.load_path($M) loads $M into current namespace.")
-
-    is_pure_julia(M) in [true, false, :unknown] ||
-        error(message*"is_pure_julia($M) must return true or false. ")
-
-    d = LittleDict{Symbol,Any}()
-    d[:name] = name(M)
-    d[:docstring] = docstring(M)
-    d[:package_name] = package_name(M)
-    d[:package_url] = package_url(M)
-    d[:package_uuid] = package_uuid(M)
-    d[:package_license] = package_license(M)
-    d[:load_path] = load_path(M)
-    d[:is_wrapper] = is_wrapper(M)
-    d[:is_pure_julia] = is_pure_julia(M)
-    d[:supports_weights] = supports_weights(M)
-    d[:is_supervised] = true
-    d[:prediction_type] = prediction_type(M)
-    d[:input_scitype] = input_scitype(M)
-    d[:target_scitype] = target_scitype(M)
-    return d
-end
-
-function info(M::Type{<:Unsupervised})
-
-    message = "$M has a bad trait declaration. "
-
-    load_path != "unknown" || error(message*"MLJBase.load_path($M) should be defined so that "* 
-                                    "using MLJ; import MLJ.load_path($M) loads $M into current namespace.")
-
-    is_pure_julia(M) in [true, false, :unknown] ||
-        error(message*"is_pure_julia($M) must return true or false. ")
-
-    d = LittleDict{Symbol,Any}()
-    d[:name] = name(M)
-    d[:docstring] = docstring(M)
-    d[:package_name] = package_name(M)
-    d[:package_url] = package_url(M)
-    d[:package_uuid] = package_uuid(M)
-    d[:package_license] = package_license(M)
-    d[:load_path] = load_path(M)
-    d[:is_wrapper] = is_wrapper(M)
-    d[:is_pure_julia] = is_pure_julia(M)
-    d[:is_supervised] = false
-    d[:input_scitype] = input_scitype(M)
-    d[:output_scitype] = output_scitype(M)
-
-    return d
-end
-
+info(M::Type{<:Supervised}) = info(M, SUPERVISED_TRAITS)
+info(M::Type{<:Unsupervised}) = info(M, UNSUPERVISED_TRAITS)
 info(model::Model) = info(typeof(model))
+
+function info(M::Type{<:Model}, traits)
+
+    message = "$M has a bad trait declaration.\n"
+
+    load_path(M) == "unknown" &&
+        error(message*"MLJBase.load_path($M) should be defined so that "* 
+              "using MLJ; import MLJ.load_path($M) loads $M into "*
+              "current namespace.")
+
+    is_pure_julia(M) in [true, false, missing] ||
+        error(message*"is_pure_julia($M) must return true, false or missing. ")
+
+    :supports_weights in traits &&
+        !(supports_weights(M) isa Bool) &&
+        error(message*"supports_weights($M) must return true, false or missing. ")
+
+    :is_wrapper in traits &&
+        !(is_wrapper(M) isa Bool) &&
+        error(message*"is_wrapper($M) must return true, false or missing. ")
+    
+    return LittleDict{Symbol,Any}(trait => eval(:($trait))(M)
+                                  for trait in traits)
+end
+

--- a/src/init.jl
+++ b/src/init.jl
@@ -1,6 +1,11 @@
 using Requires
 
 function __init__()
+    ScientificTypes.TRAIT_FUNCTION_GIVEN_NAME[:supervised_model] =
+        x-> x isa Supervised
+    ScientificTypes.TRAIT_FUNCTION_GIVEN_NAME[:unsupervised_model] =
+        x-> x isa Unsupervised
+    ScientificTypes.TRAIT_FUNCTION_GIVEN_NAME[:measure] =  is_measure
     @require(CSV="336ed68f-0bac-5ca0-87d4-7b16caf5d00b",
              include("datasets_requires.jl"))
     @require(LossFunctions="30fc2ffe-d236-52d8-8643-a9d8f7c094a7",

--- a/src/init.jl
+++ b/src/init.jl
@@ -3,4 +3,6 @@ using Requires
 function __init__()
     @require(CSV="336ed68f-0bac-5ca0-87d4-7b16caf5d00b",
              include("datasets_requires.jl"))
+    @require(LossFunctions="30fc2ffe-d236-52d8-8643-a9d8f7c094a7",
+             include("loss_functions_interface.jl"))
 end

--- a/src/init.jl
+++ b/src/init.jl
@@ -1,5 +1,6 @@
 using Requires
 
 function __init__()
-    @require CSV="336ed68f-0bac-5ca0-87d4-7b16caf5d00b" include("datasets.jl")
+    @require(CSV="336ed68f-0bac-5ca0-87d4-7b16caf5d00b",
+             include("datasets_requires.jl"))
 end

--- a/src/loss_functions_interface.jl
+++ b/src/loss_functions_interface.jl
@@ -1,0 +1,57 @@
+# implementation of MLJ measure interface for LossFunctions.jl 
+
+import .LossFunctions: DistanceLoss, MarginLoss, SupervisedLoss
+# import LossFunctions: DistanceLoss, MarginLoss, SupervisedLoss
+
+
+is_measure(::SupervisedLoss) = true
+
+orientation(::Type{<:SupervisedLoss}) = :loss 
+reports_each_observation(::Type{<:SupervisedLoss}) = true
+is_feature_dependent(::Type{<:SupervisedLoss}) = false
+supports_weights(::Type{<:SupervisedLoss}) = true
+
+
+## DISTANCE BASED LOSS FUNCTION
+
+prediction_type(::Type{<:DistanceLoss}) = :deterministic
+target_scitype(::Type{<:DistanceLoss}) = AbstractArray{<:Continuous}
+
+value(measure::DistanceLoss, yhat, X, y, ::Nothing, ::Val{false}, ::Val{true}) =
+    measure(yhat, y)
+
+value(measure::DistanceLoss, yhat, X, y, w, ::Val{false}, ::Val{true}) =
+    w .* measure(yhat, y) ./ (sum(w)/length(y))
+
+
+## MARGIN BASED LOSS FUNCTIONS
+
+prediction_type(::Type{<:MarginLoss}) = :probabilistic
+target_scitype(::Type{<:MarginLoss}) = AbstractArray{<:Binary}
+
+# convert a Binary vector into vector of +1 or -1 values (for testing
+# only):
+pm1(y) = Int8(2).*(Int8.(MLJBase.int(y))) .- Int8(3)
+
+# rescale [0, 1] -> [-1, 1]
+_scale(p) = 2p - 1
+
+
+function value(measure::MarginLoss, yhat,
+               X, y, ::Nothing, ::Val{false}, ::Val{true})
+    check_pools(yhat, y)
+    probs_of_observed = broadcast(pdf, yhat, y)
+    return broadcast(measure, _scale.(probs_of_observed), 1)
+end
+
+value(measure::MarginLoss, yhat, X, y, w, ::Val{false}, ::Val{true}) =
+    w .* value(measure, yhat, X, y, nothing) ./ (sum(w)/length(y))
+
+
+
+
+
+
+
+
+

--- a/src/measures.jl
+++ b/src/measures.jl
@@ -1,7 +1,6 @@
 ## TRAITS FOR MEASURES
 
 is_measure(::Any) = false
-ScientificTypes.TRAIT_FUNCTION_GIVEN_NAME[:measure] =  is_measure
  
 const MEASURE_TRAITS =
     [:name, :target_scitype, :supports_weights, :prediction_type, :orientation,

--- a/src/measures.jl
+++ b/src/measures.jl
@@ -88,7 +88,7 @@ is_measure(::Measure) = true
 Base.show(stream::IO, ::MIME"text/plain", m::Measure) = print(stream, "$(name(m)) (callable Measure)")
 Base.show(stream::IO, m::Measure) = print(stream, name(m))
 
-MLJBase.traits(measure, ::Val{:measure}) = 
+MLJBase.info(measure, ::Val{:measure}) = 
     (name=name(measure),
      target_scitype=target_scitype(measure),
      prediction_type=prediction_type(measure),
@@ -109,7 +109,7 @@ Mean absolute error (also known as MAE).
 
 ``\\text{MAV} =  n^{-1}∑ᵢ|yᵢ-ŷᵢ|`` or ``\\text{MAV} =  ∑ᵢwᵢ|yᵢ-ŷᵢ|/∑ᵢwᵢ``
 
-For more information, run `MLJBase.info(mav)`.
+For more information, run `MLJBase.info_dict(mav)`.
 
 """
 mav = MAV()
@@ -161,7 +161,7 @@ Root mean squared error:
 
 ``\\text{RMS} = \\sqrt{n^{-1}∑ᵢ|yᵢ-ŷᵢ|^2}`` or ``\\text{RMS} = \\sqrt{\\frac{∑ᵢwᵢ|yᵢ-ŷᵢ|^2}{∑ᵢwᵢ}}``
 
-For more information, run `MLJBase.info(rms)`.
+For more information, run `MLJBase.info_dict(rms)`.
 
 """
 rms = RMS()
@@ -200,7 +200,7 @@ struct L2 <: Measure end
 
 L2 per-observation loss.
 
-For more information, run `MLJBase.info(l2)`.
+For more information, run `MLJBase.info_dict(l2)`.
 
 """
 l2 = L2()
@@ -229,7 +229,7 @@ struct L1 <: Measure end
 
 L1 per-observation loss.
 
-For more information, run `MLJBase.info(l1)`.
+For more information, run `MLJBase.info_dict(l1)`.
 
 """
 l1 = L1()
@@ -259,7 +259,7 @@ Root mean squared logarithmic error:
 
 ``\\text{RMSL} = n^{-1}∑ᵢ\\log\\left({yᵢ \\over ŷᵢ}\\right)``
 
-For more information, run `MLJBase.info(rmsl)`.
+For more information, run `MLJBase.info_dict(rmsl)`.
 
 See also [`rmslp1`](@ref).
 
@@ -292,7 +292,7 @@ Root mean squared logarithmic error with an offset of 1:
 
 ``\\text{RMSLP1} = n^{-1}∑ᵢ\\log\\left({yᵢ + 1 \\over ŷᵢ + 1}\\right)``
 
-For more information, run `MLJBase.info(rmslp1)`.
+For more information, run `MLJBase.info_dict(rmslp1)`.
 
 See also [`rmsl`](@ref).
 """
@@ -326,7 +326,7 @@ Root mean squared percentage loss:
 where the sum is over indices such that `yᵢ≂̸0` and `m` is the number
 of such indices.
 
-For more information, run `MLJBase.info(rmsp)`.
+For more information, run `MLJBase.info_dict(rmsp)`.
 
 """
 rmsp = RMSP()
@@ -365,7 +365,7 @@ Returns the rate of misclassification of the (point) predictions `ŷ`,
 given true observations `y`, optionally weighted by the weights
 `w`. All three arguments must be abstract vectors of the same length.
 
-For more information, run `MLJBase.info(misclassification_rate)`.
+For more information, run `MLJBase.info_dict(misclassification_rate)`.
 
 """
 misclassification_rate = MisclassificationRate()
@@ -398,7 +398,7 @@ probabilistic predictions) and an abstract vector of true observations
 `y`, return the negative log-probability that each observation would
 occur, according to the corresponding probabilistic prediction.
 
-For more information, run `MLJBase.info(cross_entropy)`.
+For more information, run `MLJBase.info_dict(cross_entropy)`.
 
 """
 cross_entropy = CrossEntropy()

--- a/src/measures.jl
+++ b/src/measures.jl
@@ -1,0 +1,443 @@
+## TRAITS FOR MEASURES
+
+is_measure(::Any) = false
+ScientificTypes.TRAIT_FUNCTION_GIVEN_NAME[:measure] =  is_measure
+ 
+const MEASURE_TRAITS =
+    [:name, :target_scitype, :supports_weights, :prediction_type, :orientation,
+     :reports_each_observation, :is_feature_dependent]
+
+# already defined in model_traits.jl:
+# name              - fallback for non-MLJType is string(M) where M is arg
+# target_scitype    - fallback value = Unknown
+# supports_weights  - fallback value = false
+# prediction_type   - fallback value = :unknown (also: :deterministic,
+#                                           :probabilistic, :interval)
+
+# specfic to measures:
+orientation(::Type) = :loss  # other options are :score, :other
+reports_each_observation(::Type) = false
+is_feature_dependent(::Type) = false
+
+# extend to instances:
+orientation(m) = orientation(typeof(m))
+reports_each_observation(m) = reports_each_observation(typeof(m))
+is_feature_dependent(m) = is_feature_dependent(typeof(m))
+
+# specific to probabilistic measures:
+distribution_type(::Type) = missing
+
+
+## DISPATCH FOR EVALUATION
+
+# yhat - predictions (point or probabilisitic)
+# X - features
+# y - target observations
+# w - per-observation weights
+
+value(measure, yhat, X, y, w) = value(measure, yhat, X, y, w,
+                                      Val(is_feature_dependent(measure)),
+                                      Val(supports_weights(measure)))
+
+
+## DEFAULT EVALUATION INTERFACE
+
+#  is feature independent, weights not supported:
+value(measure, yhat, X, y, w, ::Val{false}, ::Val{false}) = measure(yhat, y)
+
+#  is feature dependent:, weights not supported:
+value(measure, yhat, X, y, w, ::Val{true}, ::Val{false}) = measure(yhat, X, y)
+
+
+#  is feature independent, weights supported:
+value(measure, yhat, X, y, w, ::Val{false}, ::Val{true}) = measure(yhat, y, w)
+value(measure, yhat, X, y, ::Nothing, ::Val{false}, ::Val{true}) = measure(yhat, y)
+
+#  is feature dependent, weights supported:
+value(measure, yhat, X, y, w, ::Val{true}, ::Val{true}) = measure(yhat, X, y, w)
+value(measure, yhat, X, y, ::Nothing, ::Val{true}, ::Val{true}) = measure(yhat, X, y)
+
+
+## HELPERS
+
+"""
+    check_dimension(ŷ, y)
+
+Check that two vectors have compatible dimensions
+"""
+function check_dimensions(ŷ::AbstractVector, y::AbstractVector)
+    length(y) == length(ŷ) ||
+        throw(DimensionMismatch("Differing numbers of observations and "*
+                                "predictions. "))
+    return nothing
+end
+
+function check_pools(ŷ, y)
+              y[1].pool.index == classes(ŷ[1])[1].pool.index ||
+              error("Conflicting categorical pools found "*
+                    "in observations and predictions. ")
+    return nothing
+end
+
+              
+## FOR BUILT-IN MEASURES
+
+abstract type Measure <: MLJType end
+is_measure(::Measure) = true
+
+
+Base.show(stream::IO, ::MIME"text/plain", m::Measure) = print(stream, "$(name(m)) (callable Measure)")
+Base.show(stream::IO, m::Measure) = print(stream, name(m))
+
+MLJBase.traits(measure, ::Val{:measure}) = 
+    (name=name(measure),
+     target_scitype=target_scitype(measure),
+     prediction_type=prediction_type(measure),
+     orientation=orientation(measure),
+     reports_each_observation=reports_each_observation(measure),
+     is_feature_dependent=is_feature_dependent(measure),
+     supports_weights=supports_weights(measure))
+
+
+## REGRESSOR METRICS (FOR DETERMINISTIC PREDICTIONS)
+
+mutable struct MAV<: Measure end
+"""
+    mav(ŷ, y)
+    mav(ŷ, y, w)
+
+Mean absolute error (also known as MAE).
+
+``\\text{MAV} =  n^{-1}∑ᵢ|yᵢ-ŷᵢ|`` or ``\\text{MAV} =  ∑ᵢwᵢ|yᵢ-ŷᵢ|/∑ᵢwᵢ``
+
+For more information, run `MLJBase.info(mav)`.
+
+"""
+mav = MAV()
+name(::Type{<:MAV}) = "mav"
+
+target_scitype(::Type{<:MAV}) = Union{AbstractVector{Continuous},AbstractVector{Count}}
+prediction_type(::Type{<:MAV}) = :deterministic
+orientation(::Type{<:MAV}) = :loss
+reports_each_observation(::Type{<:MAV}) = false
+is_feature_dependent(::Type{<:MAV}) = false
+supports_weights(::Type{<:MAV}) = true
+
+function (::MAV)(ŷ::AbstractVector{<:Real}, y::AbstractVector{<:Real})
+    check_dimensions(ŷ, y)
+    ret = 0.0
+    for i in eachindex(y)
+        dev = y[i] - ŷ[i]
+        ret += abs(dev)
+    end
+    return ret / length(y)
+end
+
+function (::MAV)(ŷ::AbstractVector{<:Real}, y::AbstractVector{<:Real}, w::AbstractVector{<:Real})
+    check_dimensions(ŷ, y)
+    check_dimensions(y, w)
+    ret = 0.0
+    for i in eachindex(y)
+        dev = w[i]*(y[i] - ŷ[i])
+        ret += abs(dev)
+    end
+    return ret / sum(w)
+end
+
+# synonym
+"""
+mae(ŷ, y)
+
+See also [`mav`](@ref).
+"""
+const mae = mav
+
+
+struct RMS <: Measure end
+"""
+    rms(ŷ, y)
+    rms(ŷ, y, w)
+
+Root mean squared error:
+
+``\\text{RMS} = \\sqrt{n^{-1}∑ᵢ|yᵢ-ŷᵢ|^2}`` or ``\\text{RMS} = \\sqrt{\\frac{∑ᵢwᵢ|yᵢ-ŷᵢ|^2}{∑ᵢwᵢ}}``
+
+For more information, run `MLJBase.info(rms)`.
+
+"""
+rms = RMS()
+name(::Type{<:RMS}) = "rms"
+target_scitype(::Type{<:RMS}) = Union{AbstractVector{Continuous},AbstractVector{Count}}
+prediction_type(::Type{<:RMS}) = :deterministic
+orientation(::Type{<:RMS}) = :loss
+reports_each_observation(::Type{<:RMS}) = false
+is_feature_dependent(::Type{<:RMS}) = false
+supports_weights(::Type{<:RMS}) = true
+
+function (::RMS)(ŷ::AbstractVector{<:Real}, y::AbstractVector{<:Real})
+    check_dimensions(ŷ, y)
+    ret = 0.0
+    for i in eachindex(y)
+        dev = y[i] - ŷ[i]
+        ret += dev * dev
+    end
+    return sqrt(ret / length(y))
+end
+
+function (::RMS)(ŷ::AbstractVector{<:Real}, y::AbstractVector{<:Real}, w::AbstractVector{<:Real})
+    check_dimensions(ŷ, y)
+    ret = 0.0
+    for i in eachindex(y)
+        dev = y[i] - ŷ[i]
+        ret += w[i]*dev*dev
+    end
+    return sqrt(ret / sum(w))
+end
+
+struct L2 <: Measure end
+"""
+    l2(ŷ, y)
+    l2(ŷ, y, w)
+
+L2 per-observation loss.
+
+For more information, run `MLJBase.info(l2)`.
+
+"""
+l2 = L2()
+name(::Type{<:L2}) = "l2"
+target_scitype(::Type{<:L2}) = Union{AbstractVector{Continuous},AbstractVector{Count}}
+prediction_type(::Type{<:L2}) = :deterministic
+orientation(::Type{<:L2}) = :loss
+reports_each_observation(::Type{<:L2}) = true
+is_feature_dependent(::Type{<:L2}) = false
+supports_weights(::Type{<:L2}) = true
+
+function (::L2)(ŷ::AbstractVector{<:Real}, y::AbstractVector{<:Real})
+    (check_dimensions(ŷ, y); (y - ŷ).^2)
+end
+
+function (::L2)(ŷ::AbstractVector{<:Real}, y::AbstractVector{<:Real}, w::AbstractVector{<:Real})
+    check_dimensions(ŷ, y)
+    check_dimensions(w, y)
+    return (y - ŷ).^2 .* w ./ (sum(w)/length(y)) 
+end
+
+struct L1 <: Measure end
+"""
+    l1(ŷ, y)
+    l1(ŷ, y, w)
+
+L1 per-observation loss.
+
+For more information, run `MLJBase.info(l1)`.
+
+"""
+l1 = L1()
+name(::Type{<:L1}) = "l1"
+target_scitype(::Type{<:L1}) = Union{AbstractVector{Continuous},AbstractVector{Count}}
+prediction_type(::Type{<:L1}) = :deterministic
+orientation(::Type{<:L1}) = :loss
+reports_each_observation(::Type{<:L1}) = true
+is_feature_dependent(::Type{<:L1}) = false
+supports_weights(::Type{<:L1}) = true
+
+function (::L1)(ŷ::AbstractVector{<:Real}, y::AbstractVector{<:Real})
+    (check_dimensions(ŷ, y); abs.(y - ŷ))
+end
+
+function (::L1)(ŷ::AbstractVector{<:Real}, y::AbstractVector{<:Real}, w::AbstractVector{<:Real})
+    check_dimensions(ŷ, y)
+    check_dimensions(w, y)
+    return abs.(y - ŷ) .* w ./ (sum(w)/length(y))
+end
+
+struct RMSL <: Measure end
+"""
+    rmsl(ŷ, y)
+
+Root mean squared logarithmic error:
+
+``\\text{RMSL} = n^{-1}∑ᵢ\\log\\left({yᵢ \\over ŷᵢ}\\right)``
+
+For more information, run `MLJBase.info(rmsl)`.
+
+See also [`rmslp1`](@ref).
+
+"""
+rmsl = RMSL()
+name(::Type{<:RMSL}) = "rmsl"
+target_scitype(::Type{<:RMSL}) = Union{AbstractVector{Continuous},AbstractVector{Count}}
+prediction_type(::Type{<:RMSL}) = :deterministic
+orientation(::Type{<:RMSL}) = :loss
+reports_each_observation(::Type{<:RMSL}) = false
+is_feature_dependent(::Type{<:RMSL}) = false
+supports_weights(::Type{<:RMSL}) = false
+
+function (::RMSL)(ŷ::AbstractVector{<:Real}, y::AbstractVector{<:Real})
+    check_dimensions(ŷ, y)
+    ret = 0.0
+    for i in eachindex(y)
+        dev = log(y[i]) - log(ŷ[i])
+        ret += dev * dev
+    end
+    return sqrt(ret / length(y))
+end
+
+
+struct RMSLP1 <: Measure end
+"""
+    rmslp1(ŷ, y)
+
+Root mean squared logarithmic error with an offset of 1:
+
+``\\text{RMSLP1} = n^{-1}∑ᵢ\\log\\left({yᵢ + 1 \\over ŷᵢ + 1}\\right)``
+
+For more information, run `MLJBase.info(rmslp1)`.
+
+See also [`rmsl`](@ref).
+"""
+rmslp1 = RMSLP1()
+name(::Type{<:RMSLP1}) = "rmslp1"
+target_scitype(::Type{<:RMSLP1}) = Union{AbstractVector{Continuous},AbstractVector{Count}}
+prediction_type(::Type{<:RMSLP1}) = :deterministic
+orientation(::Type{<:RMSLP1}) = :loss
+reports_each_observation(::Type{<:RMSLP1}) = false
+is_feature_dependent(::Type{<:RMSLP1}) = false
+supports_weights(::Type{<:RMSLP1}) = false
+
+function (::RMSLP1)(ŷ::AbstractVector{<:Real}, y::AbstractVector{<:Real})
+    check_dimensions(ŷ, y)
+    ret = 0.0
+    for i in eachindex(y)
+        dev = log(y[i] + 1) - log(ŷ[i] + 1)
+        ret += dev * dev
+    end
+    return sqrt(ret / length(y))
+end
+
+struct RMSP <: Measure end
+"""
+    rmsp(ŷ, y)
+
+Root mean squared percentage loss:
+
+``\\text{RMSP} = m^{-1}∑ᵢ \\left({yᵢ-ŷᵢ \\over yᵢ}\\right)^2``
+
+where the sum is over indices such that `yᵢ≂̸0` and `m` is the number
+of such indices.
+
+For more information, run `MLJBase.info(rmsp)`.
+
+"""
+rmsp = RMSP()
+name(::Type{<:RMSP}) = "rmsp"
+target_scitype(::Type{<:RMSP}) = Union{AbstractVector{Continuous},AbstractVector{Count}}
+prediction_type(::Type{<:RMSP}) = :deterministic
+orientation(::Type{<:RMSP}) = :loss
+reports_each_observation(::Type{<:RMSP}) = false
+is_feature_dependent(::Type{<:RMSP}) = false
+supports_weights(::Type{<:RMSP}) = false
+
+function (::RMSP)(ŷ::AbstractVector{<:Real}, y::AbstractVector{<:Real})
+    check_dimensions(ŷ, y)
+    ret = 0.0
+    count = 0
+    for i in eachindex(y)
+        if y[i] != 0.0
+            dev = (y[i] - ŷ[i])/y[i]
+            ret += dev * dev
+            count += 1
+        end
+    end
+    return sqrt(ret/count)
+end
+
+
+## CLASSIFICATION METRICS (FOR DETERMINISTIC PREDICTIONS)
+
+struct MisclassificationRate <: Measure end
+
+"""
+    misclassification_rate(ŷ, y)
+    misclassification_rate(ŷ, y, w)
+
+Returns the rate of misclassification of the (point) predictions `ŷ`,
+given true observations `y`, optionally weighted by the weights
+`w`. All three arguments must be abstract vectors of the same length.
+
+For more information, run `MLJBase.info(misclassification_rate)`.
+
+"""
+misclassification_rate = MisclassificationRate()
+name(::Type{<:MisclassificationRate}) = "misclassification_rate"
+target_scitype(::Type{<:MisclassificationRate}) = AbstractVector{<:Finite}
+prediction_type(::Type{<:MisclassificationRate}) = :deterministic
+orientation(::Type{<:MisclassificationRate}) = :loss
+reports_each_observation(::Type{<:MisclassificationRate}) = false
+is_feature_dependent(::Type{<:MisclassificationRate}) = false
+supports_weights(::Type{<:MisclassificationRate}) = true
+
+(::MisclassificationRate)(ŷ::AbstractVector{<:CategoricalElement},
+                          y::AbstractVector{<:CategoricalElement}) =
+                              mean(y .!= ŷ)
+(::MisclassificationRate)(ŷ::AbstractVector{<:CategoricalElement},
+                          y::AbstractVector{<:CategoricalElement},
+                          w::AbstractVector{<:Real}) =
+                              sum((y .!= ŷ) .*w) / sum(w)
+
+
+## CLASSIFICATION METRICS (FOR PROBABILISTIC PREDICTIONS)
+
+struct CrossEntropy <: Measure end
+
+"""
+    cross_entropy(ŷ, y::AbstractVector{<:Finite})
+
+Given an abstract vector of `UnivariateFinite` distributions `ŷ` (ie, of 
+probabilistic predictions) and an abstract vector of true observations
+`y`, return the negative log-probability that each observation would
+occur, according to the corresponding probabilistic prediction.
+
+For more information, run `MLJBase.info(cross_entropy)`.
+
+"""
+cross_entropy = CrossEntropy()
+name(::Type{<:CrossEntropy}) = "cross_entropy"
+target_scitype(::Type{<:CrossEntropy}) = AbstractVector{<:Finite}
+prediction_type(::Type{<:CrossEntropy}) = :probabilistic
+orientation(::Type{<:CrossEntropy}) = :loss
+reports_each_observation(::Type{<:CrossEntropy}) = true
+is_feature_dependent(::Type{<:CrossEntropy}) = false
+supports_weights(::Type{<:CrossEntropy}) = false
+
+# for single observation:
+_cross_entropy(d, y) = -log(pdf(d, y))
+
+function (::CrossEntropy)(ŷ::AbstractVector{<:UnivariateFinite},
+                          y::AbstractVector{<:CategoricalElement})
+    check_dimensions(ŷ, y)
+    check_pools(ŷ, y)          
+    return broadcast(_cross_entropy, Any[ŷ...], y)
+end
+
+
+## DEFAULT MEASURES
+
+default_measure(model::M) where M<:Supervised =
+    default_measure(model, target_scitype(M))
+default_measure(model, ::Any) = nothing
+default_measure(model::Deterministic,
+                ::Type{<:Union{AbstractVector{Continuous},
+                               AbstractVector{Count}}}) = rms
+# default_measure(model::Probabilistic,
+#                 ::Type{<:Union{AbstractVector{Continuous},
+#                                AbstractVector{Count}}}) = rms
+default_measure(model::Deterministic,
+                ::Type{<:AbstractVector{<:Finite}}) =
+                    misclassification_rate
+default_measure(model::Probabilistic,
+                ::Type{<:AbstractVector{<:Finite}}) =
+                    cross_entropy
+
+

--- a/src/model_traits.jl
+++ b/src/model_traits.jl
@@ -1,7 +1,3 @@
-ScientificTypes.TRAIT_FUNCTION_GIVEN_NAME[:supervised_model] = x-> x isa Supervised
-ScientificTypes.TRAIT_FUNCTION_GIVEN_NAME[:unsupervised_model] = x-> x isa Unsupervised
-
-
 ## MODEL TRAITS
 
 # model trait names:

--- a/src/model_traits.jl
+++ b/src/model_traits.jl
@@ -42,7 +42,8 @@ prediction_type(::Type{<:Probabilistic}) = :probabilistic
 prediction_type(::Type{<:Interval}) = :interval
 implemented_methods(M::Type{<:MLJType}) = map(f->f.name, methodswith(M))
 hyperparameters(M::Type) = collect(fieldnames(M))
-hyperparameter_types(M::Type) = collect(string.(fieldtypes(M)))
+_fieldtypes(M) = [fieldtype(M, fld) for fld in fieldnames(M)]
+hyperparameter_types(M::Type) = string.(_fieldtypes(M))
 # function hyperparmeter_defaults(M::Type)
 #     try
 #         model = M()

--- a/src/model_traits.jl
+++ b/src/model_traits.jl
@@ -46,8 +46,7 @@ prediction_type(::Type{<:Probabilistic}) = :probabilistic
 prediction_type(::Type{<:Interval}) = :interval
 implemented_methods(M::Type{<:MLJType}) = map(f->f.name, methodswith(M))
 hyperparameters(M::Type) = collect(fieldnames(M))
-hyperparameter_types(M::Type) =
-    [Meta.parse(string(T)) for T in fieldtypes(M)]
+hyperparameter_types(M::Type) = collect(string.(fieldtypes(M)))
 # function hyperparmeter_defaults(M::Type)
 #     try
 #         model = M()

--- a/src/model_traits.jl
+++ b/src/model_traits.jl
@@ -1,0 +1,67 @@
+ScientificTypes.TRAIT_FUNCTION_GIVEN_NAME[:supervised_model] = x-> x isa Supervised
+ScientificTypes.TRAIT_FUNCTION_GIVEN_NAME[:unsupervised_model] = x-> x isa Unsupervised
+
+
+## MODEL TRAITS
+
+# model trait names:
+const MODEL_TRAITS = [:input_scitype, :output_scitype, :target_scitype,
+                    :is_pure_julia, :package_name, :package_license,
+                    :load_path, :package_uuid, 
+                    :package_url, :is_wrapper, :supports_weights, :docstring,
+                    :name, :is_supervised, :prediction_type,
+                    :implemented_methods, :hyperparameters,
+                    :hyperparameter_types]
+const SUPERVISED_TRAITS = filter(MODEL_TRAITS) do trait
+    !(trait in [:output_scitype,])
+end
+const UNSUPERVISED_TRAITS = filter(MODEL_TRAITS) do trait
+    !(trait in [:target_scitype, :prediction_type, :supports_weights])
+end
+
+# fallback trait declarations:
+input_scitype(::Type) = Unknown
+output_scitype(::Type) = Unknown
+target_scitype(::Type) = Unknown  # used for measures too
+is_pure_julia(::Type) = missing
+package_name(::Type) = "unknown"
+package_license(::Type) = "unknown"
+load_path(::Type) = "unknown"
+package_uuid(::Type) = "unknown"
+package_url(::Type) = "unknown"
+is_wrapper(::Type) = false
+supports_weights(::Type) = false  # used for measures too
+docstring(object::Type{<:MLJType}) =
+    "$(name(object)) from $(package_name(object)).jl.\n"*
+"[Documentation]($(package_url(object)))."
+
+# "derived" traits:
+name(M::Type) = string(M)
+name(M::Type{<:MLJType}) = split(string(coretype(M)), '.')[end] |> String
+is_supervised(::Type{<:Type}) = false
+is_supervised(::Type{<:Supervised}) = true
+prediction_type(::Type) = :unknown # used for measures too
+prediction_type(::Type{<:Deterministic}) = :deterministic
+prediction_type(::Type{<:Probabilistic}) = :probabilistic
+prediction_type(::Type{<:Interval}) = :interval
+implemented_methods(M::Type{<:MLJType}) = map(f->f.name, methodswith(M))
+hyperparameters(M::Type) = collect(fieldnames(M))
+hyperparameter_types(M::Type) =
+    [Meta.parse(string(T)) for T in fieldtypes(M)]
+# function hyperparmeter_defaults(M::Type)
+#     try
+#         model = M()
+#         return [Meta.parse(string(getproperty(model, fld)))
+#                 for fld in fieldnames(M)]
+#     catch
+#         return []
+#     end
+# end
+                    
+
+# declare `trait(object) = trait(typeof(object))`:      
+for trait in MODEL_TRAITS
+    eval(quote
+        $trait(object) = $trait(typeof(object))
+    end)
+end

--- a/src/model_traits.jl
+++ b/src/model_traits.jl
@@ -58,9 +58,28 @@ hyperparameter_types(M::Type) = collect(string.(fieldtypes(M)))
 # end
                     
 
-# declare `trait(object) = trait(typeof(object))`:      
-for trait in MODEL_TRAITS
-    eval(quote
-        $trait(object) = $trait(typeof(object))
-    end)
-end
+# following 5 lines commented out because they dissallow precompilation:
+# for trait in MODEL_TRAITS
+#     eval(quote
+#         $trait(object) = $trait(typeof(object))
+#     end)
+# end
+
+input_scitype(object) = input_scitype(typeof(object))
+output_scitype(object) = output_scitype(typeof(object))
+target_scitype(object) = target_scitype(typeof(object))
+is_pure_julia(object) = is_pure_julia(typeof(object))
+package_name(object) = package_name(typeof(object))
+package_license(object) = package_license(typeof(object))
+load_path(object) = load_path(typeof(object))
+package_uuid(object) = package_uuid(typeof(object))
+package_url(object) = package_url(typeof(object))
+is_wrapper(object) = is_wrapper(typeof(object))
+supports_weights(object) = supports_weights(typeof(object))
+docstring(object) = docstring(typeof(object))
+name(object) = name(typeof(object))
+is_supervised(object) = is_supervised(typeof(object))
+prediction_type(object) = prediction_type(typeof(object))
+implemented_methods(object) = implemented_methods(typeof(object))
+hyperparameters(object) = hyperparameters(typeof(object))
+hyperparameter_types(object) = hyperparameter_types(typeof(object))

--- a/src/show.jl
+++ b/src/show.jl
@@ -148,7 +148,7 @@ end
 function Base.show(stream::IO, ::MIME"text/plain", object, ::Val{true})
     pretty(stream, object)
 end
-pretty(stream::IO, object) = pretty(stream, object, 0, DEFAULT_SHOW_DEPTH + 1, 0)
+pretty(stream::IO, object) = pretty(stream, object, 0, DEFAULT_SHOW_DEPTH + 2, 0)
 pretty(stream, object, current_depth, depth, n) = show(stream, object)
 function pretty(stream, object::M, current_depth, depth, n) where M<:MLJType
     if current_depth == depth

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -1,3 +1,11 @@
+function coretype(M)
+    if isdefined(M, :name)
+        return M.name
+    else
+        return coretype(M.body)
+    end
+end
+
 function finaltypes(T::Type)
     s = InteractiveUtils.subtypes(T)
     if isempty(s)

--- a/test/data.jl
+++ b/test/data.jl
@@ -81,64 +81,77 @@ end
 end
 
 
-## DECODER
+@testset "categorical element decoder, classes " begin
 
-N = 10
-mix = shuffle(0:N - 1)
+    N = 10
+    mix = shuffle(0:N - 1)
+    
+    Xraw = broadcast(x->mod(x,N), rand(Int, 2N, 3N))
+    Yraw = string.(Xraw)
+    
+    X = categorical(Xraw)
+    x = X[1]
+    Y = categorical(Yraw)
+    y = Y[1]
+    V = broadcast(identity, X)
+    W = broadcast(identity, Y)
+    Xo = levels!(deepcopy(X), mix)
+    xo = Xo[1]
+    Yo = levels!(deepcopy(Y), string.(mix))
+    yo = Yo[1]
+    Vo = broadcast(identity, Xo)
+    Wo = broadcast(identity, Yo)
 
-Xraw = broadcast(x->mod(x,N), rand(Int, 2N, 3N))
-Yraw = string.(Xraw)
+    raw(x::CategoricalElement) = x.pool.index[x.level]
+    @test raw.(classes(xo)) == xo.pool.levels
+    @test raw.(classes(yo)) == yo.pool.levels
+    
+    # getting all possible elements from one:
+    @test raw.(X) == Xraw
+    @test raw.(Y) == Yraw
+    @test raw.(classes(xo)) == levels(Xo)
+    @test raw.(classes(yo)) == levels(Yo)
+    
+    # broadcasted encoding:
+    @test int(X) == int(V)
+    @test int(Y) == int(W)
+    
+    # encoding and decoding are inverses:
+    d = decoder(xo)
+    @test d(int(Vo)) == Vo
+    e = decoder(yo)
+    @test e(int(Wo)) == Wo
+    A = sample(xo.pool.order, 100)
+    @test int(d(A)) == A
+    @test int(e(A)) == A
+    
+    # int is based on ordering not index
+    v = categorical(['a', 'b', 'c'], ordered=true)
+    @test int(v) == 1:3
+    levels!(v, ['c', 'a', 'b'])
+    @test int(v) == [2, 3, 1]
 
-X = categorical(Xraw)
-x = X[1]
-Y = categorical(Yraw)
-y = Y[1]
-V = broadcast(identity, X)
-W = broadcast(identity, Y)
-Xo = levels!(deepcopy(X), mix)
-xo = Xo[1]
-Yo = levels!(deepcopy(Y), string.(mix))
-yo = Yo[1]
-Vo = broadcast(identity, Xo)
-Wo = broadcast(identity, Yo)
+end
 
-# classes:
+@testset "table to matrix to table" begin
 
-raw(x::CategoricalElement) = x.pool.index[x.level]
-@test raw.(classes(xo)) == xo.pool.levels
-@test raw.(classes(yo)) == yo.pool.levels
+    B = rand(UInt8, (4, 5))
+    @test matrix(DataFrame(B)) == B
+    @test matrix(table(B)) == B
+    @test matrix(table(B), transpose=true) == B'
 
-# getting all possible elements from one:
-@test raw.(X) == Xraw
-@test raw.(Y) == Yraw
-@test raw.(classes(xo)) == levels(Xo)
-@test raw.(classes(yo)) == levels(Yo)
+    X  = (x1=rand(5), x2=rand(5))
 
-# broadcasted encoding:
-@test int(X) == int(V)
-@test int(Y) == int(W)
+    @test table(X, prototype=DataFrame()) == DataFrame(X)
+    T = table((x1=(1,2,3), x2=(:x, :y, :z)))
+    selectcols(T, :x1) == [1, 2, 3]
 
-# encoding and decoding are inverses:
-d = decoder(xo)
-@test d(int(Vo)) == Vo
-e = decoder(yo)
-@test e(int(Wo)) == Wo
-A = sample(xo.pool.order, 100)
-@test int(d(A)) == A
-@test int(e(A)) == A
+    v = categorical(11:20)
+    A = hcat(v, v)
+    tab = table(A)
+    selectcols(tab, 1) == v
 
-# int is based on ordering not index
-v = categorical(['a', 'b', 'c'], ordered=true)
-@test int(v) == 1:3
-levels!(v, ['c', 'a', 'b'])
-@test int(v) == [2, 3, 1]
-
-
-## MATRIX
-
-B = rand(UInt8, (4, 5))
-@test matrix(DataFrame(B)) == B
-
+end
 
 ## TABLE INDEXING
 
@@ -175,14 +188,33 @@ s = schema(df)
 @test nrows(tt) == length(tt.x1)
 @test select(tt, 2, :x2) == tt.x2[2]
 
-v = rand(Int, 4)
-@test selectrows(v, 2:3) == v[2:3]
-@test nrows(v) == 4
+@testset "vector accessors" begin
+    v = rand(Int, 4)
+    @test selectrows(v, 2:3) == v[2:3]
+    @test selectrows(v, 2) == [v[2]]
+    @test nrows(v) == 4
+
+    v = categorical(collect("asdfasdf"))
+    @test selectrows(v, 2:3) == v[2:3]
+    @test selectrows(v, 2) == [v[2]]
+    @test nrows(v) == 8
+end
+
+@testset "matrix accessors" begin
+    A = rand(5, 10)
+    @test selectrows(A, 2:4) == A[2:4,:]
+    @test selectrows(A, 2:4) == A[2:4,:]
+    @test selectrows(A, 2) == A[2:2,:]
+
+    A = rand(5, 10) |> categorical
+    @test selectrows(A, 2:4) == A[2:4,:]
+    @test selectrows(A, 2:4) == A[2:4,:]
+    @test selectrows(A, 2) == A[2:2,:]
+
+    @test nrows(A) == 5
+end
 
 v = categorical(collect("asdfasdf"))
-@test selectrows(v, 2:3) == v[2:3]
-@test nrows(v) == 8
-
 df = DataFrame(v=v, w=v)
 @test selectcols(df, :w) == v
 tt = TypedTables.Table(df)
@@ -205,12 +237,8 @@ tt = TypedTables.Table(df)
 
 
 
-## MANIFESTING ARRAYS AS TABLES
 
-A = hcat(v, v)
-tab = table(A)
-selectcols(tab, 1) == v
-matrix(tab) == A
+
 
 # uncomment 3 lines to restore JuliaDB testing:
 # sparsearray = sparse([6, 1, 1, 2, 3, 4], [2, 2, 3, 3, 1, 2],

--- a/test/data.jl
+++ b/test/data.jl
@@ -209,7 +209,7 @@ tt = TypedTables.Table(df)
 
 A = hcat(v, v)
 tab = table(A)
-tab[1] == v
+selectcols(tab, 1) == v
 matrix(tab) == A
 
 # uncomment 3 lines to restore JuliaDB testing:

--- a/test/datasets.jl
+++ b/test/datasets.jl
@@ -3,14 +3,53 @@ module TestDatasets
 # using Revise
 using Test
 using MLJBase
-using CSV
 
-task = load_boston()
-load_ames()
-load_reduced_ames()
-load_iris()
-load_crabs()
-datanow()
+X, y = @load_boston
+@test schema(X).names  == (:Crim, :Zn, :Indus, :NOx, :Rm, :Age,
+                           :Dis, :Rad, :Tax, :PTRatio, :Black, :LStat)
+@test scitype(y) <: AbstractVector{Continuous}
+
+X, y = @load_ames
+schema(X).names == (:MSSubClass, :MSZoning, :LotFrontage, :LotArea,
+                    :Street, :LotShape, :LandContour, :LotConfig,
+                    :LandSlope, :Neighborhood, :Condition1,
+                    :Condition2, :BldgType, :HouseStyle,
+                    :OverallQual, :OverallCond, :YearBuilt,
+                    :YearRemodAdd, :RoofStyle, :RoofMatl,
+                    :Exterior1st, :Exterior2nd, :MasVnrType,
+                    :MasVnrArea, :ExterQual, :ExterCond,
+                    :Foundation, :BsmtQual, :BsmtCond, :BsmtExposure,
+                    :BsmtFinType1, :BsmtFinSF1, :BsmtFinType2,
+                    :BsmtFinSF2, :BsmtUnfSF, :TotalBsmtSF, :Heating,
+                    :HeatingQC, :CentralAir, :Electrical, :x1stFlrSF,
+                    :x2ndFlrSF, :LowQualFinSF, :GrLivArea, :BsmtFullBath,
+                    :BsmtHalfBath, :FullBath, :HalfBath,
+                    :BedroomAbvGr, :KitchenAbvGr, :KitchenQual,
+                    :TotRmsAbvGrd, :Functional, :Fireplaces,
+                    :FireplaceQu, :GarageType, :GarageYrBlt,
+                    :GarageFinish, :GarageCars, :GarageArea,
+                    :GarageQual, :GarageCond, :PavedDrive,
+                    :WoodDeckSF, :OpenPorchSF, :EnclosedPorch,
+                    :x3SsnPorch, :ScreenPorch, :PoolArea, :MiscVal,
+                    :MoSold, :YrSold, :SaleType, :SaleCondition)
+@test scitype(y) <: AbstractVector{Continuous}
+
+X, y = @load_reduced_ames
+schema(X).names == (:OverallQual, :GrLivArea, :Neighborhood,
+                    :x1stFlrSF, :TotalBsmtSF, :BsmtFinSF1, :LotArea,
+                    :GarageCars, :MSSubClass, :GarageArea, :YearRemodAdd,
+                    :YearBuilt)
+@test scitype(y) <: AbstractVector{Continuous}
+
+X, y = @load_iris
+@test schema(X).names == (:sepal_length, :sepal_width, :petal_length,
+                          :petal_width)
+@test scitype(y) <: AbstractVector{<:Multiclass}
+
+X, y = @load_crabs
+@test schema(X).names ==  (:FL, :RW, :CL, :CW, :BD)
+@test scitype(y) <: AbstractVector{<:Multiclass}
+
 
 end # module
 true

--- a/test/info.jl
+++ b/test/info.jl
@@ -1,4 +1,4 @@
-module TestIntrospection
+module TestInfo
 
 # using Revise
 using MLJBase
@@ -6,38 +6,148 @@ import MLJBase
 using Test
 using OrderedCollections
 
-mutable struct Dummy <: Probabilistic end
+mutable struct DummyProb <: Probabilistic end
+MLJBase.load_path(::Type{DummyProb}) = "GreatPackage.MLJ.DummyProb"
+MLJBase.input_scitype(::Type{DummyProb}) = MLJBase.Table(Finite)
+MLJBase.target_scitype(::Type{DummyProb}) = AbstractVector{<:Continuous}
+MLJBase.is_pure_julia(::Type{DummyProb}) = true
+MLJBase.supports_weights(::Type{DummyProb}) = true
+MLJBase.package_name(::Type{DummyProb}) = "GreatPackage"
+MLJBase.package_uuid(::Type{DummyProb}) = "6f286f6a-111f-5878-ab1e-185364afe411"
+MLJBase.package_url(::Type{DummyProb}) = "https://mickey.mouse.org"
+MLJBase.package_license(::Type{DummyProb}) = "MIT"
 
-MLJBase.load_path(::Type{Dummy}) = "GreatPackage.MLJ.Dummy"
-MLJBase.input_scitype(::Type{Dummy}) = MLJBase.Table(Finite)
-MLJBase.target_scitype(::Type{Dummy}) = AbstractVector{<:Continuous}
-MLJBase.is_pure_julia(::Type{Dummy}) = true
-MLJBase.supports_weights(::Type{Dummy}) = true
-MLJBase.package_name(::Type{Dummy}) = "GreatPackage"
-MLJBase.package_uuid(::Type{Dummy}) = "6f286f6a-111f-5878-ab1e-185364afe411"
-MLJBase.package_url(::Type{Dummy}) = "https://mickey.mouse.org"
-MLJBase.package_license(::Type{Dummy}) = "MIT"
+mutable struct DummyDeterm <: Deterministic end
+MLJBase.load_path(::Type{DummyDeterm}) = "GreatPackage.MLJ.DummyDeterm"
+MLJBase.input_scitype(::Type{DummyDeterm}) = MLJBase.Table(Finite)
+MLJBase.target_scitype(::Type{DummyDeterm}) = AbstractVector{<:Continuous}
+MLJBase.is_pure_julia(::Type{DummyDeterm}) = true
+MLJBase.supports_weights(::Type{DummyDeterm}) = true
+MLJBase.package_name(::Type{DummyDeterm}) = "GreatPackage"
+MLJBase.package_uuid(::Type{DummyDeterm}) = "6f286f6a-111f-5878-ab1e-185364afe411"
+MLJBase.package_url(::Type{DummyDeterm}) = "https://mickey.mouse.org"
+MLJBase.package_license(::Type{DummyDeterm}) = "MIT"
 
-d = LittleDict{Symbol,Any}(:name => "Dummy",
-                           :load_path => "GreatPackage.MLJ.Dummy",
-                           :is_pure_julia => true,
-                           :package_uuid  => "6f286f6a-111f-5878-ab1e-185364afe411",
-                           :package_name  => "GreatPackage",
-                           :package_license => "MIT",
-                           :input_scitype => MLJBase.Table(Finite),
-                           :supports_weights => true,
-                           :target_scitype => MLJBase.AbstractVector{<:Continuous},
-                           :is_probabilistic => true,
-                           :package_url   => "https://mickey.mouse.org",
-                           :is_supervised => true,
-                           :is_wrapper => false)
+mutable struct DummyUnsup <: Unsupervised end
+MLJBase.load_path(::Type{DummyUnsup}) = "GreatPackage.MLJ.DummyUnsup"
+MLJBase.input_scitype(::Type{DummyUnsup}) = MLJBase.Table(Finite)
+MLJBase.output_scitype(::Type{DummyUnsup}) = AbstractVector{<:Continuous}
+MLJBase.is_pure_julia(::Type{DummyUnsup}) = true
+MLJBase.supports_weights(::Type{DummyUnsup}) = true
+MLJBase.package_name(::Type{DummyUnsup}) = "GreatPackage"
+MLJBase.package_uuid(::Type{DummyUnsup}) = "6f286f6a-111f-5878-ab1e-185364afe411"
+MLJBase.package_url(::Type{DummyUnsup}) = "https://mickey.mouse.org"
+MLJBase.package_license(::Type{DummyUnsup}) = "MIT"
 
-info(Dummy)[:name]
-@test info(Dummy) == d
-@test info(Dummy()) == d
-# for k in keys(d)
-#     println(string(k, " ",  info(Dummy)[k] == d[k]))
-# end
+mutable struct DummyInt <: Interval end
+MLJBase.load_path(::Type{DummyInt}) = "GreatPackage.MLJ.DummyInt"
+MLJBase.input_scitype(::Type{DummyInt}) = MLJBase.Table(Finite)
+MLJBase.target_scitype(::Type{DummyInt}) = AbstractVector{<:Continuous}
+MLJBase.is_pure_julia(::Type{DummyInt}) = true
+MLJBase.supports_weights(::Type{DummyInt}) = true
+MLJBase.package_name(::Type{DummyInt}) = "GreatPackage"
+MLJBase.package_uuid(::Type{DummyInt}) = "6f286f6a-111f-5878-ab1e-185364afe411"
+MLJBase.package_url(::Type{DummyInt}) = "https://mickey.mouse.org"
+MLJBase.package_license(::Type{DummyInt}) = "MIT"
+
+@testset "info on probabilistic models" begin
+
+    d = LittleDict{Symbol,Any}(:name => "DummyProb",
+                               :load_path => "GreatPackage.MLJ.DummyProb",
+                               :is_pure_julia => true,
+                               :package_uuid  => "6f286f6a-111f-5878-ab1e-185364afe411",
+                               :package_name  => "GreatPackage",
+                               :package_license => "MIT",
+                               :input_scitype => MLJBase.Table(Finite),
+                               :supports_weights => true,
+                               :target_scitype => MLJBase.AbstractVector{<:Continuous},
+                               :prediction_type => :probabilistic,
+                               :package_url   => "https://mickey.mouse.org",
+                               :is_supervised => true,
+                               :is_wrapper => false,
+                               :docstring => "DummyProb from GreatPackage.jl.\n[Documentation](https://mickey.mouse.org).")
+    
+    @test info(DummyProb) == d
+    @test info(DummyProb()) == d
+    # for k in keys(d)
+    #      println(string(k, " ",  info(DummyProb)[k] == d[k]))
+    # end
+end
+
+
+
+@testset "info on deterministic models" begin
+
+    d = LittleDict{Symbol,Any}(:name => "DummyDeterm",
+                               :load_path => "GreatPackage.MLJ.DummyDeterm",
+                               :is_pure_julia => true,
+                               :package_uuid  => "6f286f6a-111f-5878-ab1e-185364afe411",
+                               :package_name  => "GreatPackage",
+                               :package_license => "MIT",
+                               :input_scitype => MLJBase.Table(Finite),
+                               :supports_weights => true,
+                               :target_scitype => MLJBase.AbstractVector{<:Continuous},
+                               :prediction_type => :deterministic,
+                               :package_url   => "https://mickey.mouse.org",
+                               :is_supervised => true,
+                               :is_wrapper => false,
+                               :docstring => "DummyDeterm from GreatPackage.jl.\n[Documentation](https://mickey.mouse.org).")
+    
+    @test info(DummyDeterm) == d
+    @test info(DummyDeterm()) == d
+    # for k in keys(d)
+    #      println(string(k, " ",  info(DummyDeterm)[k] == d[k]))
+    # end
+    
+end
+
+@testset "info on interval models" begin
+
+    d = LittleDict{Symbol,Any}(:name => "DummyInt",
+                               :load_path => "GreatPackage.MLJ.DummyInt",
+                               :is_pure_julia => true,
+                               :package_uuid  => "6f286f6a-111f-5878-ab1e-185364afe411",
+                               :package_name  => "GreatPackage",
+                               :package_license => "MIT",
+                               :input_scitype => MLJBase.Table(Finite),
+                               :supports_weights => true,
+                               :target_scitype => MLJBase.AbstractVector{<:Continuous},
+                               :prediction_type => :interval,
+                               :package_url   => "https://mickey.mouse.org",
+                               :is_supervised => true,
+                               :is_wrapper => false,
+                               :docstring => "DummyInt from GreatPackage.jl.\n[Documentation](https://mickey.mouse.org).")
+    
+    @test info(DummyInt) == d
+    @test info(DummyInt()) == d
+    # for k in keys(d)
+    #      println(string(k, " ",  info(DummyInt)[k] == d[k]))
+    # end
+    
+end
+
+@testset "info on unsupervised models" begin
+
+    d = LittleDict{Symbol,Any}(:name => "DummyUnsup",
+                               :load_path => "GreatPackage.MLJ.DummyUnsup",
+                               :is_pure_julia => true,
+                               :package_uuid  => "6f286f6a-111f-5878-ab1e-185364afe411",
+                               :package_name  => "GreatPackage",
+                               :package_license => "MIT",
+                               :input_scitype => MLJBase.Table(Finite),
+                               :output_scitype => MLJBase.AbstractVector{<:Continuous},
+                               :package_url   => "https://mickey.mouse.org",
+                               :is_supervised => false,
+                               :is_wrapper => false,
+                               :docstring => "DummyUnsup from GreatPackage.jl.\n[Documentation](https://mickey.mouse.org).")
+    
+    @test info(DummyUnsup) == d
+    @test info(DummyUnsup()) == d
+    # for k in keys(d)
+    #     println(string(k, " ",  info(DummyUnsup)[k] == d[k]))
+    # end
+
+end
 
 end
 true

--- a/test/info.jl
+++ b/test/info.jl
@@ -16,6 +16,7 @@ MLJBase.package_name(::Type{DummyProb}) = "GreatPackage"
 MLJBase.package_uuid(::Type{DummyProb}) = "6f286f6a-111f-5878-ab1e-185364afe411"
 MLJBase.package_url(::Type{DummyProb}) = "https://mickey.mouse.org"
 MLJBase.package_license(::Type{DummyProb}) = "MIT"
+MLJBase.predict(::DummyProb, fr, X) = nothing
 
 mutable struct DummyDeterm <: Deterministic end
 MLJBase.load_path(::Type{DummyDeterm}) = "GreatPackage.MLJ.DummyDeterm"
@@ -27,17 +28,7 @@ MLJBase.package_name(::Type{DummyDeterm}) = "GreatPackage"
 MLJBase.package_uuid(::Type{DummyDeterm}) = "6f286f6a-111f-5878-ab1e-185364afe411"
 MLJBase.package_url(::Type{DummyDeterm}) = "https://mickey.mouse.org"
 MLJBase.package_license(::Type{DummyDeterm}) = "MIT"
-
-mutable struct DummyUnsup <: Unsupervised end
-MLJBase.load_path(::Type{DummyUnsup}) = "GreatPackage.MLJ.DummyUnsup"
-MLJBase.input_scitype(::Type{DummyUnsup}) = MLJBase.Table(Finite)
-MLJBase.output_scitype(::Type{DummyUnsup}) = AbstractVector{<:Continuous}
-MLJBase.is_pure_julia(::Type{DummyUnsup}) = true
-MLJBase.supports_weights(::Type{DummyUnsup}) = true
-MLJBase.package_name(::Type{DummyUnsup}) = "GreatPackage"
-MLJBase.package_uuid(::Type{DummyUnsup}) = "6f286f6a-111f-5878-ab1e-185364afe411"
-MLJBase.package_url(::Type{DummyUnsup}) = "https://mickey.mouse.org"
-MLJBase.package_license(::Type{DummyUnsup}) = "MIT"
+MLJBase.predict(::DummyDeterm, fr, X) = nothing
 
 mutable struct DummyInt <: Interval end
 MLJBase.load_path(::Type{DummyInt}) = "GreatPackage.MLJ.DummyInt"
@@ -49,6 +40,19 @@ MLJBase.package_name(::Type{DummyInt}) = "GreatPackage"
 MLJBase.package_uuid(::Type{DummyInt}) = "6f286f6a-111f-5878-ab1e-185364afe411"
 MLJBase.package_url(::Type{DummyInt}) = "https://mickey.mouse.org"
 MLJBase.package_license(::Type{DummyInt}) = "MIT"
+MLJBase.predict(::DummyInt, fr, X) = nothing
+
+mutable struct DummyUnsup <: Unsupervised end
+MLJBase.load_path(::Type{DummyUnsup}) = "GreatPackage.MLJ.DummyUnsup"
+MLJBase.input_scitype(::Type{DummyUnsup}) = MLJBase.Table(Finite)
+MLJBase.output_scitype(::Type{DummyUnsup}) = AbstractVector{<:Continuous}
+MLJBase.is_pure_julia(::Type{DummyUnsup}) = true
+MLJBase.supports_weights(::Type{DummyUnsup}) = true
+MLJBase.package_name(::Type{DummyUnsup}) = "GreatPackage"
+MLJBase.package_uuid(::Type{DummyUnsup}) = "6f286f6a-111f-5878-ab1e-185364afe411"
+MLJBase.package_url(::Type{DummyUnsup}) = "https://mickey.mouse.org"
+MLJBase.package_license(::Type{DummyUnsup}) = "MIT"
+MLJBase.transform(::DummyUnsup, fr, X) = nothing
 
 @testset "info on probabilistic models" begin
 
@@ -65,7 +69,8 @@ MLJBase.package_license(::Type{DummyInt}) = "MIT"
                                :package_url   => "https://mickey.mouse.org",
                                :is_supervised => true,
                                :is_wrapper => false,
-                               :docstring => "DummyProb from GreatPackage.jl.\n[Documentation](https://mickey.mouse.org).")
+                               :docstring => "DummyProb from GreatPackage.jl.\n[Documentation](https://mickey.mouse.org).",
+                               :implemented_methods => [:predict, ])
     
     @test info(DummyProb) == d
     @test info(DummyProb()) == d
@@ -91,7 +96,8 @@ end
                                :package_url   => "https://mickey.mouse.org",
                                :is_supervised => true,
                                :is_wrapper => false,
-                               :docstring => "DummyDeterm from GreatPackage.jl.\n[Documentation](https://mickey.mouse.org).")
+                               :docstring => "DummyDeterm from GreatPackage.jl.\n[Documentation](https://mickey.mouse.org).",
+                               :implemented_methods => [:predict, ])
     
     @test info(DummyDeterm) == d
     @test info(DummyDeterm()) == d
@@ -102,7 +108,7 @@ end
 end
 
 @testset "info on interval models" begin
-
+    
     d = LittleDict{Symbol,Any}(:name => "DummyInt",
                                :load_path => "GreatPackage.MLJ.DummyInt",
                                :is_pure_julia => true,
@@ -116,7 +122,8 @@ end
                                :package_url   => "https://mickey.mouse.org",
                                :is_supervised => true,
                                :is_wrapper => false,
-                               :docstring => "DummyInt from GreatPackage.jl.\n[Documentation](https://mickey.mouse.org).")
+                               :docstring => "DummyInt from GreatPackage.jl.\n[Documentation](https://mickey.mouse.org).",
+                               :implemented_methods => [:predict, ])
     
     @test info(DummyInt) == d
     @test info(DummyInt()) == d
@@ -139,7 +146,8 @@ end
                                :package_url   => "https://mickey.mouse.org",
                                :is_supervised => false,
                                :is_wrapper => false,
-                               :docstring => "DummyUnsup from GreatPackage.jl.\n[Documentation](https://mickey.mouse.org).")
+                               :docstring => "DummyUnsup from GreatPackage.jl.\n[Documentation](https://mickey.mouse.org).",
+                               :implemented_methods => [:transform, ])
     
     @test info(DummyUnsup) == d
     @test info(DummyUnsup()) == d

--- a/test/info.jl
+++ b/test/info.jl
@@ -2,7 +2,7 @@ module TestInfo
 
 # using Revise
 using MLJBase
-import MLJBase
+import MLJBase.info_dict
 using Test
 using OrderedCollections
 
@@ -82,10 +82,10 @@ MLJBase.transform(::DummyUnsup, fr, X) = nothing
                                                     :a_vector, :untyped])
     
     
-    @test info(DummyProb) == d
-    @test info(DummyProb(42, 3.14, [1.0, 2.0], :cow)) == d
+    @test info_dict(DummyProb) == d
+    @test info_dict(DummyProb(42, 3.14, [1.0, 2.0], :cow)) == d
     # for k in keys(d)
-    #       println(string(k, " ",  info(DummyProb)[k] == d[k]))
+    #       println(string(k, " ",  info_dict(DummyProb)[k] == d[k]))
     # end
 end
 
@@ -112,10 +112,10 @@ end
                                :hyperparameters => [])
 
     
-    @test info(DummyDeterm) == d
-    @test info(DummyDeterm()) == d
+    @test info_dict(DummyDeterm) == d
+    @test info_dict(DummyDeterm()) == d
     # for k in keys(d)
-    #      println(string(k, " ",  info(DummyDeterm)[k] == d[k]))
+    #      println(string(k, " ",  info_dict(DummyDeterm)[k] == d[k]))
     # end
     
 end
@@ -140,10 +140,10 @@ end
                                :hyperparameter_types  => [],
                                :hyperparameters => [])
     
-    @test info(DummyInt) == d
-    @test info(DummyInt()) == d
+    @test info_dict(DummyInt) == d
+    @test info_dict(DummyInt()) == d
     # for k in keys(d)
-    #      println(string(k, " ",  info(DummyInt)[k] == d[k]))
+    #      println(string(k, " ",  info_dict(DummyInt)[k] == d[k]))
     # end
     
 end
@@ -166,10 +166,10 @@ end
                                :hyperparameter_types  => [],
                                :hyperparameters => [])
     
-    @test info(DummyUnsup) == d
-    @test info(DummyUnsup()) == d
+    @test info_dict(DummyUnsup) == d
+    @test info_dict(DummyUnsup()) == d
     # for k in keys(d)
-    #     println(string(k, " ",  info(DummyUnsup)[k] == d[k]))
+    #     println(string(k, " ",  info_dict(DummyUnsup)[k] == d[k]))
     # end
 
 end

--- a/test/info.jl
+++ b/test/info.jl
@@ -76,8 +76,8 @@ MLJBase.transform(::DummyUnsup, fr, X) = nothing
                                :is_wrapper => false,
                                :docstring => "DummyProb from GreatPackage.jl.\n[Documentation](https://mickey.mouse.org).",
                                :implemented_methods => [:predict, ],
-                               :hyperparameter_types  => [:Int64, :Float64,
-                                                     :(Array{Float64, 1}), :(Any)],
+                               :hyperparameter_types  => ["Int64", "Float64",
+                                                     "Array{Float64,1}", "Any"],
                                :hyperparameters => [:an_int, :a_float,
                                                     :a_vector, :untyped])
     
@@ -85,7 +85,7 @@ MLJBase.transform(::DummyUnsup, fr, X) = nothing
     @test info(DummyProb) == d
     @test info(DummyProb(42, 3.14, [1.0, 2.0], :cow)) == d
     # for k in keys(d)
-    #      println(string(k, " ",  info(DummyProb)[k] == d[k]))
+    #       println(string(k, " ",  info(DummyProb)[k] == d[k]))
     # end
 end
 

--- a/test/info.jl
+++ b/test/info.jl
@@ -6,7 +6,12 @@ import MLJBase
 using Test
 using OrderedCollections
 
-mutable struct DummyProb <: Probabilistic end
+mutable struct DummyProb <: Probabilistic
+    an_int::Int
+    a_float::Float64
+    a_vector::Vector{Float64}
+    untyped
+end
 MLJBase.load_path(::Type{DummyProb}) = "GreatPackage.MLJ.DummyProb"
 MLJBase.input_scitype(::Type{DummyProb}) = MLJBase.Table(Finite)
 MLJBase.target_scitype(::Type{DummyProb}) = AbstractVector{<:Continuous}
@@ -70,10 +75,15 @@ MLJBase.transform(::DummyUnsup, fr, X) = nothing
                                :is_supervised => true,
                                :is_wrapper => false,
                                :docstring => "DummyProb from GreatPackage.jl.\n[Documentation](https://mickey.mouse.org).",
-                               :implemented_methods => [:predict, ])
+                               :implemented_methods => [:predict, ],
+                               :hyperparameter_types  => [:Int64, :Float64,
+                                                     :(Array{Float64, 1}), :(Any)],
+                               :hyperparameters => [:an_int, :a_float,
+                                                    :a_vector, :untyped])
+    
     
     @test info(DummyProb) == d
-    @test info(DummyProb()) == d
+    @test info(DummyProb(42, 3.14, [1.0, 2.0], :cow)) == d
     # for k in keys(d)
     #      println(string(k, " ",  info(DummyProb)[k] == d[k]))
     # end
@@ -97,7 +107,10 @@ end
                                :is_supervised => true,
                                :is_wrapper => false,
                                :docstring => "DummyDeterm from GreatPackage.jl.\n[Documentation](https://mickey.mouse.org).",
-                               :implemented_methods => [:predict, ])
+                               :implemented_methods => [:predict, ],
+                               :hyperparameter_types  => [],
+                               :hyperparameters => [])
+
     
     @test info(DummyDeterm) == d
     @test info(DummyDeterm()) == d
@@ -123,7 +136,9 @@ end
                                :is_supervised => true,
                                :is_wrapper => false,
                                :docstring => "DummyInt from GreatPackage.jl.\n[Documentation](https://mickey.mouse.org).",
-                               :implemented_methods => [:predict, ])
+                               :implemented_methods => [:predict, ],
+                               :hyperparameter_types  => [],
+                               :hyperparameters => [])
     
     @test info(DummyInt) == d
     @test info(DummyInt()) == d
@@ -147,7 +162,9 @@ end
                                :is_supervised => false,
                                :is_wrapper => false,
                                :docstring => "DummyUnsup from GreatPackage.jl.\n[Documentation](https://mickey.mouse.org).",
-                               :implemented_methods => [:transform, ])
+                               :implemented_methods => [:transform, ],
+                               :hyperparameter_types  => [],
+                               :hyperparameters => [])
     
     @test info(DummyUnsup) == d
     @test info(DummyUnsup()) == d

--- a/test/loss_functions_interface.jl
+++ b/test/loss_functions_interface.jl
@@ -1,6 +1,9 @@
+module TestLossFunctionsInterface
+
 # using Revise
-using MLJBase
+import MLJBase
 using Test
+using Statistics
 using LossFunctions
 import Random.seed!
 using CategoricalArrays
@@ -12,8 +15,8 @@ seed!(1234)
 
     y =    categorical(["yes", "yes", "no", "yes"])
     yes, no = y[1], y[3]
-    dyes = UnivariateFinite([yes, no], [0.6, 0.4])
-    dno =  UnivariateFinite([yes, no], [0.3, 0.7])
+    dyes = MLJBase.UnivariateFinite([yes, no], [0.6, 0.4])
+    dno =  MLJBase.UnivariateFinite([yes, no], [0.3, 0.7])
     yhat = [dno, dno, dyes, dyes]
     X = nothing
     w = [1, 2, 3, 4]
@@ -29,7 +32,7 @@ seed!(1234)
     ym = MLJBase.pm1(y) # observations for raw LossFunctions measure
     p_vec = rand(N) # probabilities of yes
     yhat  = map(p_vec) do p
-        UnivariateFinite([yes, no], [p, 1 - p])
+        MLJBase.UnivariateFinite([yes, no], [p, 1 - p])
     end
     yhatm = MLJBase._scale.(p_vec) # predictions for raw LossFunctions measure
     w = rand(N)
@@ -59,6 +62,9 @@ seed!(1234)
     end
 
 end
+
+end
+
 true
 
     

--- a/test/loss_functions_interface.jl
+++ b/test/loss_functions_interface.jl
@@ -1,0 +1,64 @@
+# using Revise
+using MLJBase
+using Test
+using LossFunctions
+import Random.seed!
+using CategoricalArrays
+seed!(1234)
+
+@testset "interface to LossFunctions.jl" begin
+
+    # losses for binary targets:
+
+    y =    categorical(["yes", "yes", "no", "yes"])
+    yes, no = y[1], y[3]
+    dyes = UnivariateFinite([yes, no], [0.6, 0.4])
+    dno =  UnivariateFinite([yes, no], [0.3, 0.7])
+    yhat = [dno, dno, dyes, dyes]
+    X = nothing
+    w = [1, 2, 3, 4]
+
+    @test MLJBase.value(ZeroOneLoss(), yhat, X, y, nothing) ≈ [1, 1, 1, 0]
+    @test MLJBase.value(ZeroOneLoss(), yhat, X, y, w) ≈ [1, 2, 3, 0] ./10 .* 4
+
+    N = 10
+    y = categorical(rand(["yes", "no"], N), ordered=true)
+    levels!(y, ["no", "yes"])
+    no, yes = MLJBase.classes(y[1])
+    @test MLJBase.pm1([yes, no]) in [[+1, -1], [-1, +1]]
+    ym = MLJBase.pm1(y) # observations for raw LossFunctions measure
+    p_vec = rand(N) # probabilities of yes
+    yhat  = map(p_vec) do p
+        UnivariateFinite([yes, no], [p, 1 - p])
+    end
+    yhatm = MLJBase._scale.(p_vec) # predictions for raw LossFunctions measure
+    w = rand(N)
+    X = nothing
+
+    for m in [ZeroOneLoss(), L1HingeLoss(), L2HingeLoss(), LogitMarginLoss(),
+              ModifiedHuberLoss(), PerceptronLoss(), SmoothedL1HingeLoss(0.9),
+              L2MarginLoss(), ExpLoss(), SigmoidLoss(), DWDMarginLoss(0.9)]
+        @test MLJBase.value(m, yhat, X, y, nothing) ≈ m(yhatm, ym)
+        @test mean(MLJBase.value(m, yhat, X, y, w)) ≈
+            value(m, yhatm, ym, AggMode.WeightedMean(w))
+    end
+
+    # losses for continuous targets:
+
+    y  = randn(N)
+    yhat = randn(N)
+    
+
+    for m in [LPDistLoss(0.5), L1DistLoss(), L2DistLoss(),
+              HuberLoss(0.9), EpsilonInsLoss(0.9), L1EpsilonInsLoss(0.9),
+              L2EpsilonInsLoss(0.9), LogitDistLoss(), QuantileLoss(0.7)]
+
+        @test MLJBase.value(m, yhat, X, y, nothing) ≈ m(yhat, y)
+        @test mean(MLJBase.value(m, yhat, X, y, w)) ≈
+            value(m, yhat, y, AggMode.WeightedMean(w))
+    end
+
+end
+true
+
+    

--- a/test/measures.jl
+++ b/test/measures.jl
@@ -1,0 +1,85 @@
+module TestMeasures
+
+# using Revise
+using Test
+using MLJBase
+import Distributions
+using CategoricalArrays
+import Random.seed!
+seed!(1234)
+
+@testset "built-in regressor measures" begin
+
+    y    = [1, 2, 3, 4]
+    yhat = [4, 3, 2, 1]
+    w = [1, 2, 4, 3]
+    @test isapprox(mav(yhat, y), 2)
+    @test isapprox(mav(yhat, y, w), 9/5)
+    @test isapprox(rms(yhat, y), sqrt(5))
+    @test isapprox(rms(yhat, y, w), sqrt(21/5))
+    @test isapprox(mean(l1(yhat, y)), 2)
+    @test isapprox(mean(l1(yhat, y, w)), 9/5)
+    @test isapprox(mean(l2(yhat, y)), 5)
+    @test isapprox(mean(l2(yhat, y, w)), 21/5)
+                   
+    yhat = y .+ 1
+    @test isapprox(rmsl(yhat, y),
+                   sqrt((log(1/2)^2 + log(2/3)^2 + log(3/4)^2 + log(4/5)^2)/4))
+    @test isapprox(rmslp1(yhat, y),
+                   sqrt((log(2/3)^2 + log(3/4)^2 + log(4/5)^2 + log(5/6)^2)/4))
+    @test isapprox(rmsp(yhat, y), sqrt((1 + 1/4 + 1/9 + 1/16)/4))
+
+end
+
+@testset "built-in classifier measures" begin
+
+    y    = categorical(collect("asdfasdfaaassdd"))
+    yhat = categorical(collect("asdfaadfaasssdf"))
+    w = 1:15
+    @test misclassification_rate(yhat, y) ≈ 0.2
+    @test misclassification_rate(yhat, y, w) ≈ 4/15
+    y = categorical(collect("abb"))
+    L = [y[1], y[2]]
+    d1 = UnivariateFinite(L, [0.1, 0.9])
+    d2 = UnivariateFinite(L, [0.4, 0.6])
+    d3 = UnivariateFinite(L, [0.2, 0.8])
+    yhat = [d1, d2, d3]
+    @test mean(cross_entropy(yhat, y)) ≈ -(log(0.1) + log(0.6) + log(0.8))/3
+
+end
+
+@testset "MLJBase.value" begin
+
+    yhat = rand(5)
+    X = (weight=rand(5), x1 = rand(5))
+    y = rand(5)
+    w = rand(5)
+
+    @test MLJBase.value(mav, yhat, nothing, y, nothing) ≈ mav(yhat, y) 
+    @test MLJBase.value(mav, yhat, nothing, y, w) ≈ mav(yhat, y, w) 
+
+    spooky(yhat, y) = abs.(yhat - y) |> mean
+    @test MLJBase.value(spooky, yhat, nothing, y, nothing) ≈ mav(yhat, y)
+    
+    cool(yhat, y, w) = abs.(yhat - y) .* w ./ (sum(w)/length(y)) |> mean
+    MLJBase.supports_weights(::Type{typeof(cool)}) = true
+    @test MLJBase.value(cool, yhat, nothing, y, w) ≈ mav(yhat, y, w)
+    
+    funky(yhat, X, y) = X.weight .* abs.(yhat - y) ./ (sum(X.weight)/length(y)) |> mean
+    MLJBase.is_feature_dependent(::Type{typeof(funky)}) = true
+    @test MLJBase.value(funky, yhat, X, y, nothing) ≈ mav(yhat, y, X.weight)
+
+    weird(yhat, X, y, w) = w .* X.weight .* abs.(yhat - y) ./ sum(w .* X.weight) |> sum
+    MLJBase.is_feature_dependent(::Type{typeof(weird)}) = true
+    MLJBase.supports_weights(::Type{typeof(weird)}) = true
+    @test MLJBase.value(weird, yhat, X, y, w) ≈ mav(yhat, y, X.weight .* w)
+
+end
+
+# for when ROC is added as working dependency:
+# y = ["n", "p", "n", "p", "n", "p"]
+# yhat = [0.1, 0.2, 0.3, 0.6, 0.7, 0.8]
+# @test auc("p")(yhat, y) ≈ 2/3
+
+end
+true

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -38,3 +38,12 @@ end
 @testset "tasks" begin
   @test include("tasks.jl")
 end
+
+@testset "measures" begin
+  @test include("measures.jl")
+end
+
+@testset "interface for LossFunctions" begin
+  @test include("loss_functions_interface.jl")
+end
+


### PR DESCRIPTION
- Bump ScientificTypes requirement to v0.2.0

- (Enhancement) The performance measures API (built-in measures +
  adaptor for external measures) from MLJ has been migrated to MLJBase.
  MLJ.
  
- (Breaking) `info`, which returns a dictionary (needed for TOML
  serialization) is renamed to `info_dic`. In this way "info" is
  reserved for a method in MLJModels/MLJ that returns a
  more-convenient named-tuple

- (Breaking) The `is_probabilistic` model trait is replaced with
  `prediction_type`, which can have the values `:deterministic`,
  `:probabilistic` or `:interval`, to allow for models predicting real
  intervals, and for consistency with measures API.
  
- (Bug fix, mildly breaking) The `package_license` model trait is now included in
  `info_dict` in the case of unsupervisd models.
  
- (Enhancement, mildly breaking) Add new model traits `hyperparameters`, 
  `hyperparameter_types`, `docstring`, and `implemented_operations` (`fit`, `predict`, `inverse_transform`, etc) ([#36](https://github.com/alan-turing-institute/MLJBase.jl/issues/36),  [#37](https://github.com/alan-turing-institute/MLJBase.jl/issues/37), [#38](https://github.com/alan-turing-institute/MLJBase.jl/issues/38))
  
- (Enhancement) The `MLJBase.table` and `MLJBase.matrix` operations
  are now direct wraps of the corresponding `Tables.jl` operations for
  improved performance. In particular
  `MLJBase.matrix(MLJBase.table(A))` is essentially a non-operation,
  and one can pass `MLJBase.matrix` the keyword argument
  `transpose=...` .
  
- (Breaking) The built-in dataset methods `load_iris`, `load_boston`,
  `load_ames`, `load_reduced_ames`, `load_crabs` return a raw
  `DataFrame`, instead of an `MLJTask` object, and continue to require
  `import CSV` to become available. However, macro versions
  `@load_iris`, etc, are always available, automatically triggering
  `import CSV`; these macros return a tuple `(X, y)` of input
  `DataFrame` and target vector `y`, with scitypes appropriately
  coerced. (MLJ
  [#224](https://github.com/alan-turing-institute/MLJ.jl/issues/224))
  
- (Enhancement) `selectrows` now works for matrices. Needed to allow
  matrices as "node type" in MLJ learning networks; see [MLJ
  #209](https://github.com/alan-turing-institute/MLJ.jl/issues/209).

- (Bug) Fix problem with `==` for `MLJType` objects
  ([#35](https://github.com/alan-turing-institute/MLJBase.jl/issues/35))

- (Breaking) Update requirement on ScientficTypes.jl to v0.2.0 to
  mitigate bug with coercion of column scitypes for tables that are
  also AbstractVectors, and to make `coerce` more convenient.
