### PR TITLE
using significant digits rounding in show of univariatefinite

### DIFF
--- a/src/distributions.jl
+++ b/src/distributions.jl
@@ -150,10 +150,10 @@ function Base.show(stream::IO, d::UnivariateFinite)
                                 # instantiation of d
     x1 = d.decoder(first(raw))
     p1 = d.prob_given_class[first(raw)]
-    str = "UnivariateFinite($x1=>$p1"
+    str = "UnivariateFinite($x1=>$(round(p1, sigdigits=3))"
     pairs = (d.decoder(r)=>d.prob_given_class[r] for r in raw[2:end])
     for pair in pairs
-        str *= ", $(pair[1])=>$(pair[2])"
+        str *= ", $(pair[1])=>$(round(pair[2], sigdigits=3))"
     end
     str *= ")"
     print(stream, str)


### PR DESCRIPTION
Before

```
UnivariateFinite(f=>0.313470891723578, m=>0.686529108276422)
```

After

```
UnivariateFinite(f=>0.313, m=>0.687)
```

**Note**: uses *sigdigits* rounding so if there are very low numbers, they won't get zeroed but showed as `5.67e-5`:

```
julia> round(0.00001351035, sigdigits=3)
1.35e-5
```