### PR TITLE
Improvements to classes and int

### DIFF
--- a/src/data.jl
+++ b/src/data.jl
@@ -139,20 +139,7 @@ true, `x in x.pool.levels` is not true.
      :c
 
 """
-function classes(p::CategoricalPool)
-    ls = p.levels
-    # Standard approach is the list comprehension
-    eltype(ls) !== Any && return [p.valindex[p.invindex[l]] for l in ls]
-    # If the eltype is Any, we need  to be careful otherwise Julia
-    # stackoverflows; there is potentially a bug in CategoricalArrays
-    # see also issue MLJModels#126. The approach below, as weird as it may
-    # look, is the only way I could find to make it work.
-    classes_ = copy(p.valindex)
-    @inbounds for i in eachindex(ls)
-        classes_[i] = p.valindex[p.invindex[ls[i]]]
-    end
-    return classes_
-end
+classes(p::CategoricalPool) = [p[i] for i in CategoricalArrays.order(p)]
 classes(x::CategoricalElement) = classes(x.pool)
 
 """
@@ -186,12 +173,12 @@ Broadcasted versions of `int`.
 
 See also: [`decoder`](@ref).
 """
-int(x::CategoricalElement) = x.pool.order[x.pool.invindex[x]]
+int(x::CategoricalElement) = CategoricalArrays.order(x.pool)[x.level]
 int(A::AbstractArray) = broadcast(int, A)
 
 # get the integer representation of a level given pool (private
 # method):
-int(pool::CategoricalPool, level) =  pool.order[pool.invindex[level]]
+int(pool::CategoricalPool, level) = CategoricalArrays.order(pool)[level]
 
 struct CategoricalDecoder{T,R} # <: MLJType
     pool::CategoricalPool{T,R}

--- a/src/equality.jl
+++ b/src/equality.jl
@@ -56,19 +56,13 @@ MLJBase.isequal(m1::MLJType, m2::MLJType) = (m1 === m2)
 
 # Note: To prevent julia crash, it seems we mysteriously need to
 # annotate the type of itr:
-function special_in(x, itr)
-    anymissing = false
-    for y in itr
-        v = (y === x)
-        if ismissing(v)
-            anymissing = true
-        elseif v
-            return true
-        end
+function special_in(x::MLJType, itr)
+    for el in itr
+        ismissing(el) && return missing
+        x === el && return true
     end
-    return anymissing ? missing : false
+    return false
 end
 Base.in(x::MLJType, itr::Set) = special_in(x, itr)
 Base.in(x::MLJType, itr::AbstractVector) = special_in(x, itr)
 Base.in(x::MLJType, itr::NTuple) = special_in(x, itr)
-

--- a/test/data.jl
+++ b/test/data.jl
@@ -1,6 +1,5 @@
 module TestData
 
-# using Revise
 using Test
 using DataFrames
 import TypedTables
@@ -268,6 +267,18 @@ tt = TypedTables.Table(df)
 # sparsearray = sparse([6, 1, 1, 2, 3, 4], [2, 2, 3, 3, 1, 2],
 #                      ["big", "small", 17, 34, 4, "small"])
 # @test matrix(nd) == sparsearray
+
+# see issue MLJModels#126
+@testset "classes-Any" begin
+    a = categorical(Any[collect("asdfjlksjfsldkfjasldkjf")])
+    c = classes(a[1])
+    @test c isa Vector{CategoricalValue{Any,UInt32}}
+    # order is preserved
+    lvs = levels(a)
+    for i in eachindex(lvs)
+        @test c[i] == lvs[i]
+    end
+end
 
 end # module
 


### PR DESCRIPTION
See https://github.com/JuliaData/CategoricalArrays.jl/issues/220#issuecomment-551995805 for context 

(ignore the first commit which was a hack, the PR in scientific types (https://github.com/alan-turing-institute/ScientificTypes.jl/pull/39) + Milan's suggestions make a lot more sense; however it does contain a small improvement to the `special_in` function so that it returns immediately if it sees something instead of going over all elements).

I'll merge this (provided tests pass) as it fixes a severe bug; we can further discuss the coming week to see if we modify things or leave as they are