### PR TITLE
POC @static macro

### DIFF
--- a/src/MLJBase.jl
+++ b/src/MLJBase.jl
@@ -57,6 +57,7 @@ export std
 
 import Base.==
 import Base: @__doc__
+import Base.@static
 
 using Tables
 using OrderedCollections # already a dependency of StatsBase
@@ -222,6 +223,9 @@ include("measures.jl")
 
 # mlj model macro to help define models
 include("mlj_model_macro.jl")
+
+# macro for static models
+include("static_macro.jl")
 
 # metadata utils
 include("metadata_utilities.jl")

--- a/src/static_macro.jl
+++ b/src/static_macro.jl
@@ -1,0 +1,18 @@
+macro static(ex)
+    if ex.args[1] isa Expr
+        part = ex.args[1]
+        fn   = part.args[1]
+        if fn ∈ (:transform, :inverse_transform)
+            m = part.args[2] # :(s::Scaling)
+            T = m.args[2]
+
+            return esc(
+                quote
+                    $ex
+                    $fn($m, ::Nothing, args...) = $fn($m, args...)
+                end
+                )
+        end
+    end
+    ex
+end

--- a/test/static.jl
+++ b/test/static.jl
@@ -8,41 +8,54 @@ mutable struct Scale <: MLJBase.Static
     scaling::Float64
 end
 
-(s::Scale)(X) = s.scaling*X
-MLJBase.inv(s::Scale, X) = X/s.scaling
+@static function transform(s::Scale, X)
+    X isa AbstractVecOrMat && return X * s.scaling
+    MLJBase.table(s.scaling * MLJBase.matrix(X), prototype=X)
+end
+
+@static function inverse_transform(s::Scale, X)
+    X isa AbstractVecOrMat && return X / s.scaling
+    MLJBase.table(MLJBase.matrix(X) / s.scaling, prototype=X)
+end
 
 s = Scale(2)
-X = rand(2,3)
+X = randn(2, 3)
+Xt = MLJBase.table(X)
 
-# no-op:
-fitresult, _, _ = MLJBase.fit(s, 1, X)
+R = transform(s, X)
+IR = inverse_transform(s, R)
+@test IR ≈ X
 
-@test transform(s, 1, X) ≈ 2*X
-@test inverse_transform(s, 1, X) ≈ 0.5*X
+R = transform(s, Xt)
+IR = inverse_transform(s, R)
+@test MLJBase.matrix(IR) ≈ X
+
+# machine-like workflow
+R = transform(s, nothing, Xt)
+IR = inverse_transform(s, nothing, R)
+@test MLJBase.matrix(IR) ≈ X
 
 
 ## MULTIVARIATE FUNCTION
 
 mutable struct PermuteArgs <: MLJBase.Static
-    permutation::NTuple{<:Any,Int}
+    permutation::NTuple{N,Int} where N
 end
 
-(p::PermuteArgs)(args...) =
+@static transform(p::PermuteArgs, args...) =
     Tuple([args[i] for i in p.permutation])
-
-p = PermuteArgs((2,3,1))
-@test p(10, 20, 30) == (20, 30, 10)
-
-MLJBase.inv(p::PermuteArgs, args...) =
+@static inverse_transform(p::PermuteArgs, args...) =
     Tuple([args[i] for i in sortperm(p.permutation |> collect)])
 
-@test inv(p, p(10, 20, 30)...) == (10, 20, 30)
+p = PermuteArgs((2, 3, 1))
+@test transform(p, 10, 20, 30) == (20, 30, 10)
+@test inverse_transform(p, 20, 30, 10) == (10, 20, 30)
 
 # no-op
 fitresult, _, _ = MLJBase.fit(p, 1, (1, 2, 3))
 
-@test MLJBase.transform(p, fitresult, 10, 20, 30) == (20, 30, 10) 
-@test MLJBase.inverse_transform(p, fitresult, 20, 30, 10) == (10, 20, 30)
+@test transform(p, fitresult, 10, 20, 30) == (20, 30, 10)
+@test inverse_transform(p, fitresult, 20, 30, 10) == (10, 20, 30)
 
 end
 true


### PR DESCRIPTION
Note that ideally we'd need to change this naming for something else because the `@static` macro is already taken by Base and it leads to annoying warning about it breaking compilation and similar  nonsense.

Given that this feature is not set in stone, we could imagine calling the whole thing differently with  possible candidates:

* `Operation` and `@operation`
* `Static` and  `@set_static` or `@declare_static` or some other alternative
* `Fixed` and `@fixed` 
* `StaticTransform` and `@statictf` or `@static_tf` or `@static_transform`

etc

Maybe "fixed" is closest to static, not sure.

Context for this discussion, https://github.com/alan-turing-institute/MLJ.jl/issues/291