### PR TITLE
Reduce risk of numerical issues with cross entropy and additional tests

### DIFF
--- a/src/measures/finite.jl
+++ b/src/measures/finite.jl
@@ -12,8 +12,9 @@ Given an abstract vector of distributions `ŷ` and an abstract vector
 of true observations `y`, return the corresponding Cross-Entropy
 loss (aka log loss) scores.
 
-Since the loss is undefined for a score of `0` or `1`, probabilities
-are clipped between `eps` and `1-eps` where `eps` can be specified.
+Since the score is undefined in the case of the true observation has
+predicted probability zero, probablities are clipped between `eps` and `1-eps`
+where `eps` can be specified.
 
 If `sᵢ` is the predicted probability for the true class `yᵢ` then
 the score for that example is given by
@@ -41,7 +42,7 @@ For more information, run `info(cross_entropy)`.
 cross_entropy = CrossEntropy()
 name(::Type{<:CrossEntropy}) = "cross_entropy"
 docstring(::Type{<:CrossEntropy}) =
-    "Cross entropy loss; aliases: `cross_entropy`"
+    "Cross entropy loss with probabilities clamped between eps and 1-eps; aliases: `cross_entropy`"
 target_scitype(::Type{<:CrossEntropy}) = AbstractVector{<:Finite}
 prediction_type(::Type{<:CrossEntropy}) = :probabilistic
 orientation(::Type{<:CrossEntropy}) = :loss

--- a/src/measures/finite.jl
+++ b/src/measures/finite.jl
@@ -29,13 +29,13 @@ supports_weights(::Type{<:CrossEntropy}) = false
 distribution_type(::Type{<:CrossEntropy}) = UnivariateFinite
 
 # for single observation:
-_cross_entropy(d, y) = -log(pdf(d, y))
+_cross_entropy(d, y) = -log(clamp(pdf(d, y), eps(), 1.0-eps()))
 
 function (::CrossEntropy)(ŷ::AbstractVector{<:UnivariateFinite},
                           y::AbstractVector{<:CategoricalElement})
     check_dimensions(ŷ, y)
     check_pools(ŷ, y)
-    return broadcast(_cross_entropy, Any[ŷ...], y)
+    return broadcast(_cross_entropy, ŷ, y)
 end
 
 # TODO: support many distributions/samplers D below:
@@ -88,7 +88,7 @@ function brier_score(d::UnivariateFinite, y)
     levels = classes(d)
     pvec = broadcast(pdf, d, levels)
     offset = 1 + sum(pvec.^2)
-    return 2*pdf(d, y) - offset
+    return 2 * pdf(d, y) - offset
 end
 
 # For multiple observations:
@@ -99,7 +99,7 @@ function (::BrierScore{<:UnivariateFinite})(
     y::AbstractVector{<:CategoricalElement})
     check_dimensions(ŷ, y)
     check_pools(ŷ, y)
-    return broadcast(brier_score, Any[ŷ...], y)
+    return broadcast(brier_score, ŷ, y)
 end
 
 function (score::BrierScore{<:UnivariateFinite})(

--- a/test/measures/finite.jl
+++ b/test/measures/finite.jl
@@ -15,15 +15,31 @@ seed!(51803)
     @test misclassification_rate(yhat, y, w) ≈ 4/15
     y = categorical(collect("abb"))
     L = [y[1], y[2]]
-    d1 = UnivariateFinite(L, [0.1, 0.9])
-    d2 = UnivariateFinite(L, [0.4, 0.6])
-    d3 = UnivariateFinite(L, [0.2, 0.8])
+    d1 = UnivariateFinite(L, [0.1, 0.9]) # a
+    d2 = UnivariateFinite(L, [0.4, 0.6]) # b
+    d3 = UnivariateFinite(L, [0.2, 0.8]) # b
     yhat = [d1, d2, d3]
     @test mean(cross_entropy(yhat, y)) ≈ -(log(0.1) + log(0.6) + log(0.8))/3
+    # sklearn test
+    # >>> from sklearn.metrics import log_loss
+    # >>> log_loss(["spam", "ham", "ham", "spam","ham","ham"], [[.1, .9], [.9, .1], [.8, .2], [.35, .65], [0.2, 0.8], [0.3,0.7]])
+    # 0.6130097025803921
+    y2 = categorical(["spam", "ham", "ham", "spam", "ham", "ham"])
+    L2 = classes(y2[1])
+    yhat2 = [UnivariateFinite(L2, v) for v in (
+            [.1, .9], [.9, .1], [.8, .2], [.35, .65], [0.2, 0.8], [0.3,0.7]
+            )]
+    @test mean(cross_entropy(yhat2, y2)) ≈ 0.6130097025803921
+    # BrierScore
     scores = BrierScore()(yhat, y)
     @test scores ≈ [-1.62, -0.32, -0.08]
     wscores = BrierScore()(yhat, y, [1, 2, 7])
     @test wscores ≈ scores .* [0.3, 0.6, 2.1]
+    # sklearn test
+    # >>> from sklearn.metrics import brier_score_loss
+    # >>> brier_score_loss([1, 0, 0, 1, 0, 0], [.9, .1, .2, .65, 0.8, 0.7])
+    # 0.21875 NOTE: opposite orientation
+    @test -mean(BrierScore()(yhat2, y2)) / 2 ≈ 0.21875
 end
 
 @testset "confusion matrix" begin


### PR DESCRIPTION
* additional tests comparing with  sklearn `brier_score_loss` and `log_loss`
* clamping of `pdf(d, y)` in `_cross_entropy` to `[eps(), 1-eps()]` to avoid numerical issues
* get rid of stray  `Any[ŷ...]` which are not necessary as far as I can tell
* allow passing a clamping epsilon to cross entropy (most likely this won't be used but it matches what sklearn  provides)