### PR TITLE
minor refactor of default_measure to address #51 and a minor bug

### DIFF
--- a/src/measures/measures.jl
+++ b/src/measures/measures.jl
@@ -135,6 +135,5 @@ default_measure(::Type{<:Deterministic},
 default_measure(::Type{<:Probabilistic},
                 ::Type{<:AbstractVector{<:Finite}}) = cross_entropy
 
-
-default_measure(model::M) where M<:Supervised =
-    default_measure(M, target_scitype(M))
+default_measure(M::Type{<:Supervised})= default_measure(M, target_scitype(M))
+default_measure(model::M) where M<:Supervised = default_measure(M)

--- a/src/measures/measures.jl
+++ b/src/measures/measures.jl
@@ -123,19 +123,18 @@ include("loss_functions_interface.jl")
 
 
 ## DEFAULT MEASURES
+default_measure(T, S) = nothing
+default_measure(::Type{<:Deterministic},
+                ::Type{<:Union{AbstractVector{<:Continuous},
+                               AbstractVector{<:Count}}}) = rms
+default_measure(::Type{<:Deterministic},
+                ::Type{<:AbstractVector{<:Finite}}) = misclassification_rate
+# default_measure(::Type{Probabilistic},
+#                 ::Type{<:Union{AbstractVector{<:Continuous},
+#                                AbstractVector{<:Count}}}) = ???
+default_measure(::Type{<:Probabilistic},
+                ::Type{<:AbstractVector{<:Finite}}) = cross_entropy
+
 
 default_measure(model::M) where M<:Supervised =
-    default_measure(model, target_scitype(M))
-default_measure(model, ::Any) = nothing
-default_measure(model::Deterministic,
-                ::Type{<:Union{AbstractVector{Continuous},
-                               AbstractVector{Count}}}) = rms
-# default_measure(model::Probabilistic,
-#                 ::Type{<:Union{AbstractVector{Continuous},
-#                                AbstractVector{Count}}}) = rms
-default_measure(model::Deterministic,
-                ::Type{<:AbstractVector{<:Finite}}) =
-                    misclassification_rate
-default_measure(model::Probabilistic,
-                ::Type{<:AbstractVector{<:Finite}}) =
-                    cross_entropy
+    default_measure(M, target_scitype(M))

--- a/test/measures/measures.jl
+++ b/test/measures/measures.jl
@@ -28,4 +28,32 @@ end
         UnivariateFinite
 end
 
+mutable struct DRegressor <: Deterministic end
+MLJBase.target_scitype(::Type{<:DRegressor}) =
+    AbstractVector{<:Continuous}
+
+mutable struct D2Regressor <: Deterministic end
+MLJBase.target_scitype(::Type{<:D2Regressor}) =
+    AbstractVector{Continuous}
+
+mutable struct DClassifier <: Deterministic end
+MLJBase.target_scitype(::Type{<:DClassifier}) =
+    AbstractVector{<:Finite}
+
+mutable struct PClassifier <: Probabilistic end
+MLJBase.target_scitype(::Type{<:PClassifier}) = 
+    AbstractVector{<:Finite}
+
+@testset "default_measure" begin
+    @test MLJBase.default_measure(DRegressor()) == rms
+    @test MLJBase.default_measure(D2Regressor()) == rms
+    @test MLJBase.default_measure(DClassifier()) == misclassification_rate
+    @test MLJBase.default_measure(PClassifier()) == cross_entropy
+
+    @test MLJBase.default_measure(DRegressor) == rms
+    @test MLJBase.default_measure(D2Regressor) == rms
+    @test MLJBase.default_measure(DClassifier) == misclassification_rate
+    @test MLJBase.default_measure(PClassifier) == cross_entropy
+end
+
 true


### PR DESCRIPTION
The minor bug is this:

If `target_scitype(model) = AbstractVector{<:Continuous}` instead of `target_scitype(model) = AbstractVector{Continuous}` then `default_measure(model) = nothing` in cases it should be `rms` (say). This is despite the fact that `Continuous` actually has no proper subtypes. 