### PR TITLE
For a 0.11.8 release

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MLJBase"
 uuid = "a7f614a8-145f-11e9-1d2a-a57a1082229d"
 authors = ["Anthony D. Blaom <anthony.blaom@gmail.com>"]
-version = "0.11.3"
+version = "0.11.4"
 
 [deps]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"

--- a/Project.toml
+++ b/Project.toml
@@ -1,11 +1,7 @@
 name = "MLJBase"
 uuid = "a7f614a8-145f-11e9-1d2a-a57a1082229d"
 authors = ["Anthony D. Blaom <anthony.blaom@gmail.com>"]
-<<<<<<< HEAD
-version = "0.11.6"
-=======
 version = "0.11.7"
->>>>>>> master
 
 [deps]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MLJBase"
 uuid = "a7f614a8-145f-11e9-1d2a-a57a1082229d"
 authors = ["Anthony D. Blaom <anthony.blaom@gmail.com>"]
-version = "0.11.5"
+version = "0.11.6"
 
 [deps]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MLJBase"
 uuid = "a7f614a8-145f-11e9-1d2a-a57a1082229d"
 authors = ["Anthony D. Blaom <anthony.blaom@gmail.com>"]
-version = "0.11.7"
+version = "0.11.8"
 
 [deps]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"

--- a/README.md
+++ b/README.md
@@ -1,18 +1,56 @@
 ## MLJBase
 
-The model interface for
-[MLJ](https://github.com/alan-turing-institute/MLJ.jl), a Julia
-machine learning framework.
+Repository for developers that provides core functionality for the
+[MLJ](https://github.com/alan-turing-institute/MLJ.jl) machine
+learning framework.
 
 [![Build Status](https://travis-ci.com/alan-turing-institute/MLJBase.jl.svg?branch=master)](https://travis-ci.com/alan-turing-institute/MLJBase.jl)
 [![Coverage](http://codecov.io/github/alan-turing-institute/MLJBase.jl/coverage.svg?branch=master)](http://codecov.io/github/alan-turing-institute/MLJBase.jl?branch=master)
 
-MLJ is a Julia framework for combining and tuning machine learning
-models. Any machine learning algorithm written in Julia can be used
-with MLJ if it is defined in a package that imports the MLJBase
-module, and implements the model API defined there. For more
-information, see the MLJ document ["Adding Models for General Use"](https://alan-turing-institute.github.io/MLJ.jl/dev/adding_models_for_general_use/).
+[MLJ](https://github.com/alan-turing-institute/MLJ.jl) is a Julia
+framework for combining and tuning machine learning models. This
+repository provides core functionality for MLJ, including:
 
-Requires at least Julia v1.0.
+- completing the functionality for methods defined "minimally" in
+  MLJ's light-weight model interface
+  [MLJModelInterface](https://github.com/alan-turing-institute/MLJModelInterface.jl)
+
+- definition of **machines** and their associated methods, such as
+  `fit!` and `predict`/`transform`
+  
+- MLJ's **model composition** interface, including **learning
+  networks** and **pipelines**
+
+- basic utilities for **manipulating data**
+
+- an extension to
+  [Distributions.jl](https://github.com/JuliaStats/Distributions.jl)
+  called `UnivariateFinite` for randomly sampling *labeled*
+  categorical data
+
+- a [small interface](https://alan-turing-institute.github.io/MLJ.jl/dev/evaluating_model_performance/#Custom-resampling-strategies-1) for **resampling strategies** and implementations, including `CV()`, `StratifiedCV` and `Holdout`
+
+- methods for **performance evaluation**, based on those resampling strategies
+
+- **one-dimensional hyperparameter range types**, constructors and
+  associated methods, for use with
+  [MLJTuning](https://github.com/alan-turing-institute/MLJTuning.jl)
+
+- a [small
+  interface](https://alan-turing-institute.github.io/MLJ.jl/dev/performance_measures/#Traits-and-custom-measures-1)
+  for **performance measures** (losses and scores), enabling the
+  integration of the
+  [LossFunctions.jl](https://github.com/JuliaML/LossFunctions.jl)
+  library, user-defined measures, as well as about two dozen natively
+  defined measures.
+
+- integration with [OpenML](https://www.openml.org)
+
+
+Previously MLJBase provided the model interface for integrating third
+party machine learning models into MLJ. That role has now shifted to
+the light-weight
+[MLJModelInterface](https://github.com/alan-turing-institute/MLJModelInterface.jl)
+package.
 
 

--- a/src/MLJBase.jl
+++ b/src/MLJBase.jl
@@ -188,6 +188,7 @@ export TruePositive, TrueNegative, FalsePositive, FalseNegative,
        falsenegative_rate, negativepredicitive_value,
        positivepredictive_value, tpr, tnr, fpr, fnr,
        falsediscovery_rate, fdr, npv, ppv,
+       fn, fp, tn, tp,
        recall, sensitivity, hit_rate, miss_rate,
        specificity, selectivity, f1score, fallout
 

--- a/src/measures/confusion_matrix.jl
+++ b/src/measures/confusion_matrix.jl
@@ -54,6 +54,12 @@ current order unless the user explicitly specifies either `rev` or
 `perm` in which case it's assumed the user is aware of the class
 ordering.
 
+The `confusion_matrix` is a measure (although neither a score nor a
+loss) and so may be specified as such in calls to `evaluate`,
+`evaluate!`, although not in `TunedModel`s.  In this case, however,
+there no way to specify an ordering different from `levels(y)`, where
+`y` is the target. 
+
 """
 function confusion_matrix(ŷ::Vec{<:CategoricalElement}, y::Vec{<:CategoricalElement};
                           rev::Union{Nothing,Bool}=nothing,

--- a/src/measures/finite.jl
+++ b/src/measures/finite.jl
@@ -503,7 +503,7 @@ $(docstring(TruePositive()))
     tp(ŷ, y)
 
 Number of true positives for observations `ŷ` and ground truth
-`y`. Assigns `true` to first element of `levels(y)`. To reverse roles,
+`y`. Assigns `false` to first element of `levels(y)`. To reverse roles,
 use `TruePositive(rev=true)` instead of `tp`.
 
 For more information, run `info(tp)`.
@@ -520,7 +520,7 @@ $(docstring(TrueNegative()))
     tn(ŷ, y)
 
 Number of true negatives for observations `ŷ` and ground truth
-`y`. Assigns `true` to first element of `levels(y)`. To reverse roles,
+`y`. Assigns `false` to first element of `levels(y)`. To reverse roles,
 use `TrueNegative(rev=true)` instead of `tn`.
 
 
@@ -537,7 +537,7 @@ $(docstring(FalsePositive()))
     fp(ŷ, y)
 
 Number of false positives for observations `ŷ` and ground truth
-`y`. Assigns `true` to first element of `levels(y)`. To reverse roles,
+`y`. Assigns `false` to first element of `levels(y)`. To reverse roles,
 use `FalsePositive(rev=true)` instead of `fp`.
 
 
@@ -554,7 +554,7 @@ $(docstring(FalseNegative()))
     fn(ŷ, y)
 
 Number of false positives for observations `ŷ` and ground truth
-`y`. Assigns `true` to first element of `levels(y)`. To reverse roles,
+`y`. Assigns `false` to first element of `levels(y)`. To reverse roles,
 use `FalseNegative(rev=true)` instead of `fn`.
 
 For more information, run `info(fn)`.
@@ -571,7 +571,7 @@ $(docstring(TruePositiveRate()))
     tpr(ŷ, y)
 
 True positive rate for observations `ŷ` and ground truth `y`. Assigns
-`true` to first element of `levels(y)`. To reverse roles, use
+`false` to first element of `levels(y)`. To reverse roles, use
 `TPR(rev=true)` instead of `tpr`.
 
 For more information, run `info(tpr)`.
@@ -593,7 +593,7 @@ $(docstring(TrueNegativeRate()))
     tpr(ŷ, y)
 
 True negative rate for observations `ŷ` and ground truth `y`. Assigns
-`true` to first element of `levels(y)`. To reverse roles, use
+`false` to first element of `levels(y)`. To reverse roles, use
 `TNR(rev=true)` instead of `tnr`.
 
 For more information, run `info(tnr)`.
@@ -614,7 +614,7 @@ $(docstring(FalsePositiveRate()))
     fpr(ŷ, y)
 
 False positive rate for observations `ŷ` and ground truth `y`. Assigns
-`true` to first element of `levels(y)`. To reverse roles, use
+`false` to first element of `levels(y)`. To reverse roles, use
 `FPR(rev=true)` instead of `fpr`.
 
 """
@@ -631,7 +631,7 @@ $(docstring(FalseNegativeRate()))
     fnr(ŷ, y)
 
 False negative rate for observations `ŷ` and ground truth `y`. Assigns
-`true` to first element of `levels(y)`. To reverse roles, use
+`false` to first element of `levels(y)`. To reverse roles, use
 `FNR(rev=true)` instead of `fnr`.
 
 For more information, run `info(fnr)`.
@@ -650,7 +650,7 @@ $(docstring(FalseDiscoveryRate()))
     fdr(ŷ, y)
 
 False discovery rate for observations `ŷ` and ground truth `y`. Assigns
-`true` to first element of `levels(y)`. To reverse roles, use
+`false` to first element of `levels(y)`. To reverse roles, use
 `FDR(rev=true)` instead of `fdr`.
 
 For more information, run `info(fdr)`.
@@ -669,7 +669,7 @@ $(docstring(NPV()))
     npv(ŷ, y)
 
 Negative predictive value for observations `ŷ` and ground truth
-`y`. Assigns `true` to first element of `levels(y)`. To reverse roles,
+`y`. Assigns `false` to first element of `levels(y)`. To reverse roles,
 use `NPV(rev=true)` instead of `npv`.
 
 For more information, run `info(npv)`.
@@ -686,7 +686,7 @@ $(docstring(Precision()))
     ppv(ŷ, y)
 
 Positive predictive value for observations `ŷ` and ground truth
-`y`. Assigns `true` to first element of `levels(y)`. To reverse roles,
+`y`. Assigns `false` to first element of `levels(y)`. To reverse roles,
 use `Precision(rev=true)` instead of `ppv`.
 
 For more information, run `info(ppv)`.

--- a/src/operations.jl
+++ b/src/operations.jl
@@ -21,7 +21,7 @@
 ## TODO: need to add checks on the arguments of
 ## predict(::AbstractMachine, ) and transform(::AbstractMachine, )
 
-for operation in (:predict, :predict_mean, :predict_mode,
+for operation in (:predict, :predict_mean, :predict_mode, :predict_median,
                   :transform, :inverse_transform)
     ex = quote
         function $(operation)(machine::AbstractMachine, args...)

--- a/test/measures/confusion_matrix.jl
+++ b/test/measures/confusion_matrix.jl
@@ -1,0 +1,76 @@
+using Test
+using MLJBase
+include(joinpath("..", "..", "test", "_models", "models.jl"))
+using .Models
+
+@testset "basics" begin
+    y = categorical(['m', 'f', 'n', 'f', 'm', 'n', 'n', 'm', 'f'])
+    ŷ = categorical(['f', 'f', 'm', 'f', 'n', 'm', 'n', 'm', 'f'])
+    l = levels(y) # f, m, n
+    cm = confmat(ŷ, y; warn=false)
+    e(l,i,j) = sum((ŷ .== l[i]) .& (y .== l[j]))
+    for i in 1:3, j in 1:3
+        @test cm[i,j] == e(l,i,j)
+    end
+    perm = [3, 1, 2]
+    l2 = l[perm]
+    cm2 = confmat(ŷ, y; perm=perm) # no warning because permutation is given
+    for i in 1:3, j in 1:3
+        @test cm2[i,j] == e(l2,i,j)
+    end
+    @test_logs (:warn, "The classes are un-ordered,\nusing order: ['f', 'm', 'n'].\nTo suppress this warning, consider coercing to OrderedFactor.") confmat(ŷ, y)
+    ŷc = coerce(ŷ, OrderedFactor)
+    yc = coerce(y, OrderedFactor)
+    @test confmat(ŷc, yc).mat == cm.mat
+
+    y = categorical(['a','b','a','b'])
+    ŷ = categorical(['b','b','a','a'])
+    @test_logs (:warn, "The classes are un-ordered,\nusing: negative='a' and positive='b'.\nTo suppress this warning, consider coercing to OrderedFactor.") confmat(ŷ, y)
+
+    # more tests for coverage
+    y = categorical([1,2,3,1,2,3,1,2,3])
+    ŷ = categorical([1,2,3,1,2,3,1,2,3])
+    @test_throws ArgumentError confmat(ŷ, y, rev=true)
+
+    # silly test for display
+    ŷ = coerce(y, OrderedFactor)
+    y = coerce(y, OrderedFactor)
+    iob = IOBuffer()
+    Base.show(iob, MIME("text/plain"), confmat(ŷ, y))
+    siob = String(take!(iob))
+    @test strip(siob) == strip("""
+                         ┌─────────────────────────────────────────┐
+                         │              Ground Truth               │
+           ┌─────────────┼─────────────┬─────────────┬─────────────┤
+           │  Predicted  │      1      │      2      │      3      │
+           ├─────────────┼─────────────┼─────────────┼─────────────┤
+           │      1      │      3      │      0      │      0      │
+           ├─────────────┼─────────────┼─────────────┼─────────────┤
+           │      2      │      0      │      3      │      0      │
+           ├─────────────┼─────────────┼─────────────┼─────────────┤
+           │      3      │      0      │      0      │      3      │
+           └─────────────┴─────────────┴─────────────┴─────────────┘""")
+
+end
+
+@testset "confmat as measure" begin
+
+    @test info(confmat).orientation == :other
+    model = DeterministicConstantClassifier()
+
+    X = (x=rand(10),)
+    long = categorical(collect("abbaacaabbbbababcbac"), ordered=true)
+    y = long[1:10]
+    yhat =long[11:20]
+
+    confmat(yhat, y).mat == [1 2 0; 3 1 1; 1 1 0]
+
+    MLJBase.value(confmat, yhat, X, y, nothing)
+
+    e = evaluate(model, X, y,
+                 measures=[misclassification_rate, confmat],
+                 resampling=Holdout(fraction_train=0.5))
+    cm = e.measurement[2]
+    @test cm.labels == ["a", "b", "c"]
+    @test cm.mat == [2 2 1; 0 0 0; 0 0 0]
+end

--- a/test/measures/measures.jl
+++ b/test/measures/measures.jl
@@ -69,6 +69,7 @@ end
 include("continuous.jl")
 include("finite.jl")
 include("loss_functions_interface.jl")
+include("confusion_matrix.jl")
 
 end
 true


### PR DESCRIPTION
- [x] (**bug**) Remove multithreading race conditions in resampling (use of `evaluate!`) (#169)

- [x] (**testing**) Fix and re-instate all `CPUThreads` and `CPUProcesses` tests in resampling

- [x] (**enhancement**) Add progress meter to all forms of accelerated resampling

- [x] (**testing**) Increase number of workers in travis testing to 2 (3 processes); increase number of threads to 2. 