### PR TITLE
Bug: fix method ambiguity for machine(::Static, args...)

### DIFF
--- a/src/composition/networks.jl
+++ b/src/composition/networks.jl
@@ -448,6 +448,7 @@ node = Node
 # NodalTrainableModel, rather than a `Machine`; it is necessary to explicitly
 # type for the first two to avoid ambiguities
 machine(m::Unsupervised, a::AbstractNode...) = NodalMachine(m, a...)
+machine(m::Static, a::AbstractNode...) = NodalMachine(m, a...)
 machine(m::Supervised,   a::AbstractNode...) = NodalMachine(m, a...)
 machine(model::Model, X, y::AbstractNode)    = NodalMachine(model, source(X), y)
 machine(model::Model, X::AbstractNode, y)    = NodalMachine(model, X, source(y))


### PR DESCRIPTION
This bug prevents using inserting static transformers in composite models, at least in some versions of julia.
