### PR TITLE
For 0.12.2 release

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MLJBase"
 uuid = "a7f614a8-145f-11e9-1d2a-a57a1082229d"
 authors = ["Anthony D. Blaom <anthony.blaom@gmail.com>"]
-version = "0.12.1"
+version = "0.12.2"
 
 [deps]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"

--- a/src/hyperparam/one_dimensional_range_methods.jl
+++ b/src/hyperparam/one_dimensional_range_methods.jl
@@ -404,7 +404,9 @@ Base.rand(rng::AbstractRNG,
     broadcast(idx -> s.values[idx], rand(rng, s.distribution, dims...))
 
 
+## SCALE METHOD FOR SAMPLERS
 
-
-#using Plots
-#plotly()
+# these mimick the definitions for 1D ranges above:
+scale(::Any) = :none
+scale(::NumericSampler) = :custom
+scale(s::NumericSampler{<:Any,<:Distributions.Sampleable,Symbol}) = s.scale

--- a/src/hyperparam/one_dimensional_range_methods.jl
+++ b/src/hyperparam/one_dimensional_range_methods.jl
@@ -278,6 +278,7 @@ end
 # constructor for distribution *instances*:
 """
     sampler(r::NominalRange, probs::AbstractVector{<:Real})
+    sampler(r::NominalRange)
     sampler(r::NumericRange{T}, d)
 
 Construct an object `s` which can be used to generate random samples
@@ -289,11 +290,12 @@ the following calls:
     rand(rng, s [, n])  # to specify an RNG
 
 The argument `probs` can be any probability vector with the same
-length as `r.values`.
+length as `r.values`. The second `sampler` method above calls the
+first with a uniform `probs` vector.
 
 The argument `d`, can be either an arbitrary instance of
 `UnivariateDistribution` from the Distributions.jl package, or one of
-the Distributions.jl types specified in the table below.
+the Distributions.jl types specified in the table below. 
 
 If `d` is an *instance*, then sampling is from a truncated form of the
 supplied distribution `d`, the truncation bounds being `r.lower` and

--- a/test/hyperparam/one_dimensional_range_methods.jl
+++ b/test/hyperparam/one_dimensional_range_methods.jl
@@ -252,6 +252,21 @@ end
     end
 
 end
+
+struct MySampler end
+Base.rand(rng::AbstractRNG, ::MySampler) = rand(rng)
+
+
+@testset "scale(s) for s a sampler" begin
+    @test scale(MySampler()) == :none
+    r = range(Char, :(model.dummy), values=collect("cab"))
+    @test scale(MLJBase.sampler(r, [0.1, 0.2, 0.7])) == :none
+    r1 = range(Int, :dummy, lower=1, upper=2, scale=x->10^x)
+    @test scale(MLJBase.sampler(r1, Dist.Uniform)) == :custom
+    r2 = range(Int, :k, lower=2, upper=6, origin=4.5, unit=1.2, scale=:log2)
+    @test scale(MLJBase.sampler(r2, Dist.Normal)) == :log2
+end
+
 end
 
 true


### PR DESCRIPTION
Minor update adding methods for samplers to the `scale` function (currently implemented for one-dimensional ranges only).