### PR TITLE
Documentation update for github pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ Manifest.toml
 #*
 .DS_Store
 sandbox/
+/docs/build/
+/docs/site/
+/docs/Manifest.toml

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,22 +10,23 @@ julia:
   - 1.2
   - 1.3
   - nightly
-matrix:
+jobs:
   allow_failures:
     - julia: nightly
+  include:
+    - if: branch = master OR tag IS present
+      stage: "Documentation"
+      julia: 1.3
+      os: linux
+      # disable global before_script in order not to install Compose twice
+      before_script:
+      script:
+        - julia --color=yes --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd()));
+                                                   Pkg.instantiate()'
+        - julia --color=yes --project=docs/ docs/make.jl
+      after_success: skip
 notifications:
   email: false
 after_success:
   # push coverage results to Codecov
   - julia -e 'using Pkg; pkg"add Coverage"; using Coverage; Codecov.submit(Codecov.process_folder())'
-
-# jobs:
-#   include:
-#     - stage: "Documentation"
-#       julia: 1.2
-#       os: linux
-#       script:
-#         - julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd()));
-#                                                Pkg.instantiate()'
-#         - julia --project=docs/ docs/make.jl
-#       after_success: skip

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,0 +1,6 @@
+[deps]
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+
+[compat]
+Documenter = "^0.24"
+julia = "1.2"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,0 +1,30 @@
+using Documenter
+using MLJBase
+
+makedocs(;
+    modules=[MLJBase],
+    format=Documenter.HTML(prettyurls = get(ENV, "CI", nothing) == "true"),
+    pages=[
+        "Home" => "index.md",
+        "Measures" => "measures.md",
+        "Resampling" => "resampling.md",
+        "Composition" => "composition.md",
+        "Datasets" => "datasets.md",
+        "Distributions" => "distributions.md",
+        "OpenML" => "openml.md",
+        "Utilities" => "utilities.md"
+    ],
+    repo="https://github.com/alan-turing-institute/MLJBase.jl/blob/{commit}{path}#L{line}",
+    sitename="MLJBase.jl"
+)
+
+# By default Documenter does not deploy docs just for PR
+# this causes issues with how we're doing things and ends
+# up choking the deployment of the docs, so  here we
+# force the environment to ignore this so that Documenter
+# does indeed deploy the docs
+ENV["TRAVIS_PULL_REQUEST"] = "false"
+
+deploydocs(;
+    repo="github.com/alan-turing-institute/MLJBase.jl.git",
+)

--- a/docs/src/composition.md
+++ b/docs/src/composition.md
@@ -1,0 +1,19 @@
+# Composition
+
+## Composites
+```@autodocs
+Modules = [MLJBase]
+Pages   = ["composition/composites.jl"]
+```
+
+## Networks
+```@autodocs
+Modules = [MLJBase]
+Pages   = ["composition/networks.jl"]
+```
+
+## Pipelines
+```@autodocs
+Modules = [MLJBase]
+Pages   = ["composition/pipeline_static.jl", "composition/pipelines.jl"]
+```

--- a/docs/src/datasets.md
+++ b/docs/src/datasets.md
@@ -1,0 +1,55 @@
+# Datasets
+```@index
+Pages   = ["data/datasets_synthetic.jl"]
+```
+
+
+## Standard datasets
+
+To add a new dataset assuming it has a header and is, at path
+`data/newdataset.csv`
+
+Start by loading it with CSV:
+```julia
+fpath = joinpath("datadir", "newdataset.csv")
+data = CSV.read(fpath, copycols=true,
+                categorical=true)
+```
+
+Load it with DelimitedFiles and Tables
+```julia
+data_raw, data_header = readdlm(fpath, ',', header=true)
+data_table = Tables.table(data_raw; header=Symbol.(vec(data_header)))
+```
+
+Retrieve the conversions:
+```julia
+for (n, st) in zip(names(data), scitype_union.(eachcol(data)))
+    println(":$n=>$st,")
+end
+```
+
+Copy and paste the result in a coerce
+```julia
+data_table = coerce(data_table, ...)
+```
+
+
+```@autodocs
+Modules = [MLJBase]
+Pages   = ["data/datasets.jl"]
+```
+
+## Synthetic datasets
+```@autodocs
+Modules = [MLJBase]
+Pages   = ["data/datasets_synthetic.jl"]
+```
+
+
+## Utility functions
+
+```@autodocs
+Modules = [MLJBase]
+Pages   = ["data/data.jl"]
+```

--- a/docs/src/distributions.md
+++ b/docs/src/distributions.md
@@ -1,0 +1,19 @@
+# Distributions
+
+## Univariate Finite Distribution
+```@autodocs
+Modules = [MLJBase]
+Pages   = ["interface/univariate_finite.jl"]
+```
+
+## hyperparameters
+```@autodocs
+Modules = [MLJBase]
+Pages   = ["hyperparam/one_dimensional_range_methods.jl", "hyperparam/one_dimensional_ranges.jl"]
+```
+
+## Utility functions
+```@autodocs
+Modules = [MLJBase]
+Pages   = ["distributions.jl"]
+```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,13 +1,4 @@
-## MLJBase
-
-Repository for developers that provides core functionality for the
-[MLJ](https://github.com/alan-turing-institute/MLJ.jl) machine
-learning framework.
-
-[![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://alan-turing-institute.github.io/MLJBase.jl/stable)
-[![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://alan-turing-institute.github.io/MLJBase.jl/dev)
-[![Build Status](https://travis-ci.com/alan-turing-institute/MLJBase.jl.svg?branch=master)](https://travis-ci.com/alan-turing-institute/MLJBase.jl)
-[![Coverage](http://codecov.io/github/alan-turing-institute/MLJBase.jl/coverage.svg?branch=master)](http://codecov.io/github/alan-turing-institute/MLJBase.jl?branch=master)
+# MLJBase.jl
 
 [MLJ](https://github.com/alan-turing-institute/MLJ.jl) is a Julia
 framework for combining and tuning machine learning models. This

--- a/docs/src/measures.md
+++ b/docs/src/measures.md
@@ -1,0 +1,25 @@
+# Measures
+
+## Helper functions
+```@autodocs
+Modules = [MLJBase]
+Pages   = ["measures/registry.jl", "measures/measures.jl"]
+```
+
+## Continuous loss functions
+```@autodocs
+Modules = [MLJBase]
+Pages   = ["measures/continuous.jl"]
+```
+
+## Confusion matrix
+```@autodocs
+Modules = [MLJBase]
+Pages   = ["measures/confusion_matrix.jl"]
+```
+
+## Finite loss functions
+```@autodocs
+Modules = [MLJBase]
+Pages   = ["measures/finite.jl"]
+```

--- a/docs/src/openml.md
+++ b/docs/src/openml.md
@@ -1,0 +1,6 @@
+# OpenML
+
+```@autodocs
+Modules = [MLJBase, OpenML]
+Pages   = ["openml.jl"]
+```

--- a/docs/src/resampling.md
+++ b/docs/src/resampling.md
@@ -1,0 +1,6 @@
+# Resampling
+
+```@autodocs
+Modules = [MLJBase]
+Pages   = ["resampling.jl"]
+```

--- a/docs/src/utilities.md
+++ b/docs/src/utilities.md
@@ -1,0 +1,25 @@
+# Utilities
+
+## Machines
+```@autodocs
+Modules = [MLJBase]
+Pages   = ["machines.jl"]
+```
+
+## Parameter Inspection
+```@autodocs
+Modules = [MLJBase]
+Pages   = ["parameter_inspection.jl"]
+```
+
+## Show
+```@autodocs
+Modules = [MLJBase]
+Pages   = ["show.jl"]
+```
+
+## Utility functions
+```@autodocs
+Modules = [MLJBase]
+Pages   = ["utilities.jl"]
+```

--- a/src/openml.jl
+++ b/src/openml.jl
@@ -19,9 +19,9 @@ const API_URL = "https://www.openml.org/api/v1/json"
 Returns information about a dataset. The information includes the name,
 information about the creator, URL to download it and more.
 
-110 - Please provide data_id.
-111 - Unknown dataset. Data set description with data_id was not found in the database.
-112 - No access granted. This dataset is not shared with you.
+- 110 - Please provide data_id.
+- 111 - Unknown dataset. Data set description with data_id was not found in the database.
+- 112 - No access granted. This dataset is not shared with you.
 """
 function load_Dataset_Description(id::Int; api_key::String="")
     url = string(API_URL, "/data/$id")
@@ -98,11 +98,12 @@ Returns a "row table", i.e., a `Vector` of identically typed
 therefore be readily converted to other compatible formats. For
 example:
 
-    using DataFrames
-    rowtable = OpenML.load(61);
-    df = DataFrame(rowtable);
-    df2 = coerce(df, :class=>Multiclass)
-
+```julia
+using DataFrames
+rowtable = OpenML.load(61);
+df = DataFrame(rowtable);
+df2 = coerce(df, :class=>Multiclass)
+```
 """
 function load(id::Int)
     response = load_Dataset_Description(id)
@@ -114,8 +115,8 @@ end
 """
 Returns a list of all data qualities in the system.
 
-412 - Precondition failed. An error code and message are returned
-370 - No data qualities available. There are no data qualities in the system.
+- 412 - Precondition failed. An error code and message are returned
+- 370 - No data qualities available. There are no data qualities in the system.
 """
 function load_Data_Qualities_List()
     url = string(API_URL, "/data/qualities/list")
@@ -136,10 +137,10 @@ end
 """
 Returns a list of all data qualities in the system.
 
-271 - Unknown dataset. Data set with the given data ID was not found (or is not shared with you).
-272 - No features found. The dataset did not contain any features, or we could not extract them.
-273 - Dataset not processed yet. The dataset was not processed yet, features are not yet available. Please wait for a few minutes.
-274 - Dataset processed with error. The feature extractor has run into an error while processing the dataset. Please check whether it is a valid supported file. If so, please contact the API admins.
+- 271 - Unknown dataset. Data set with the given data ID was not found (or is not shared with you).
+- 272 - No features found. The dataset did not contain any features, or we could not extract them.
+- 273 - Dataset not processed yet. The dataset was not processed yet, features are not yet available. Please wait for a few minutes.
+- 274 - Dataset processed with error. The feature extractor has run into an error while processing the dataset. Please check whether it is a valid supported file. If so, please contact the API admins.
 """
 function load_Data_Features(id::Int; api_key::String = "")
     if api_key == ""
@@ -168,12 +169,12 @@ end
 """
 Returns the qualities of a dataset.
 
-360 - Please provide data set ID
-361 - Unknown dataset. The data set with the given ID was not found in the database, or is not shared with you.
-362 - No qualities found. The registered dataset did not contain any calculated qualities.
-363 - Dataset not processed yet. The dataset was not processed yet, no qualities are available. Please wait for a few minutes.
-364 - Dataset processed with error. The quality calculator has run into an error while processing the dataset. Please check whether it is a valid supported file. If so, contact the support team.
-365 - Interval start or end illegal. There was a problem with the interval start or end.
+- 360 - Please provide data set ID
+- 361 - Unknown dataset. The data set with the given ID was not found in the database, or is not shared with you.
+- 362 - No qualities found. The registered dataset did not contain any calculated qualities.
+- 363 - Dataset not processed yet. The dataset was not processed yet, no qualities are available. Please wait for a few minutes.
+- 364 - Dataset processed with error. The quality calculator has run into an error while processing the dataset. Please check whether it is a valid supported file. If so, contact the support team.
+- 365 - Interval start or end illegal. There was a problem with the interval start or end.
 """
 function load_Data_Qualities(id::Int; api_key::String = "")
     if api_key == ""
@@ -227,10 +228,10 @@ specific value or a range in the form 'low..high'.
 Multiple qualities can be combined, as in
 'number_instances/0..50/number_features/0..10'.
 
-370 - Illegal filter specified.
-371 - Filter values/ranges not properly specified.
-372 - No results. There where no matches for the given constraints.
-373 - Can not specify an offset without a limit.
+- 370 - Illegal filter specified.
+- 371 - Filter values/ranges not properly specified.
+- 372 - No results. There where no matches for the given constraints.
+- 373 - Can not specify an offset without a limit.
 """
 function load_List_And_Filter(filters::String; api_key::String = "")
     if api_key == ""


### PR DESCRIPTION
This is some initial setup for MLJBase API docs.

Notes:
- `matrix` has been changed to `jobs` per this recommendation: https://juliadocs.github.io/Documenter.jl/stable/man/hosting/index.html#Travis-CI-1
- There are couple of warnings in docs build section, honestly do not know how to solve them, but it seems that final docs are fine
- One should of course setup DOCUMENTER_KEY and all other things in repo and travis CI. Also I do not know at what point travis creates `stable` version in `gh-pages`, I think simpliest solution is just to add copy of `dev` folder manually in `gh-pages` branch. 
- Unfortunately I do not know intrinsic details of MLJBase, so some docs were rather loosely put to categories, hope that's ok.

Result can be found here: https://arkoniak.github.io/MLJBase.jl/dev/