### PR TITLE
improve progressmeter display

### DIFF
--- a/src/resampling.jl
+++ b/src/resampling.jl
@@ -574,7 +574,10 @@ end
 @static if VERSION >= v"1.3.0-DEV.573"
 # one machine for each thread; cycle through available threads:
 function _evaluate!(func, machines, ::CPUThreads, nfolds, channel, verbosity)
-       
+   
+   if Threads.nthreads() == 1
+       return _evaluate!(func, machines, CPU1(), nfolds, channel, verbosity)
+   end    
    tasks= (Threads.@spawn begin
             id = Threads.threadid()
             if !haskey(machines, id)


### PR DESCRIPTION
After my last PR i decided to push the limits of the progress meter display. This lead me to make the following four changes.
1. limit the buffer size of the `RemoteChannel` to a maximum of 1000. This is to limit the size of memory allocated which may affect performance of the program depending on the platform it is ran on. This choice follows that used in [ProgressMeter](https://github.com/timholy/ProgressMeter.jl) codebase.
2. Added a yield() in the case of `CPU1` and `CPUThreads`. This is to ensure smooth updating of the progress bar especially in the case of `CPUThreads.
3. Added an  Info message in the case of `CPUThreads` similar to `CPUProcesses` to tell the user the number of threads being used.
4. Add fallback to `CPU1` when `nthreads==1`. This was done to smooth-en the display in that case.