### PR TITLE
Remove error message for running fit! on a Static transformer

### DIFF
--- a/src/operations.jl
+++ b/src/operations.jl
@@ -24,8 +24,8 @@
 for operation in (:predict, :predict_mean, :predict_mode, :predict_median,
                   :transform, :inverse_transform)
     ex = quote
-        function $(operation)(machine::AbstractMachine, args...)
-            if isdefined(machine, :fitresult)
+        function $(operation)(machine::AbstractMachine{M}, args...) where M
+            if isdefined(machine, :fitresult) || M <: Static
                 return $(operation)(machine.model, machine.fitresult, args...)
             else
                 throw(error("$machine has not been trained."))


### PR DESCRIPTION
Stop throwing error when calling an operation (eg, `transform`) on a `Static` model's machine, as there are no learned parameters.