### PR TITLE
Update train_test_pairs() for stratified CV 

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MLJBase"
 uuid = "a7f614a8-145f-11e9-1d2a-a57a1082229d"
 authors = ["Anthony D. Blaom <anthony.blaom@gmail.com>"]
-version = "0.13.1"
+version = "0.13.2"
 
 [deps]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"

--- a/src/composition/networks.jl
+++ b/src/composition/networks.jl
@@ -555,7 +555,7 @@ function models(W::AbstractNode)
 end
 
 """
-    sources(W::AbstractNode; kind=:any)
+    sources(N::AbstractNode; kind=:any)
 
 A vector of all sources referenced by calls `N()` and `fit!(N)`. These
 are the sources of the directed acyclic graph associated with the

--- a/src/resampling.jl
+++ b/src/resampling.jl
@@ -187,12 +187,9 @@ Unlike regular cross-validation, the distribution of the levels of the
 target `y` corresponding to each `train` and `test` is constrained, as
 far as possible, to replicate that of `y[rows]` as a whole.
 
-Specifically, the data is split into a number of groups on which `y`
-is constant, and each individual group is resampled according to the
-ordinary cross-validation strategy `CV(nfolds=nfolds)`. To obtain the
-final `(train, test)` pairs of row indices, the per-group pairs are
-collated in such a way that each collated `train` and `test` respects
-the original order of `rows` (after shuffling, if `shuffle=true`).
+The stratified `train_test_pairs` algorithm is invariant to label renaming.
+For example, if you run `replace!(y, 'a' => 'b', 'b' => 'a')` and then re-run
+`train_test_pairs`, the returned `(train, test)` pairs will be the same.
 
 Pre-shuffling of `rows` is controlled by `rng` and `shuffle`. If `rng`
 is an integer, then the `StratifedCV` keyword constructor resets it to

--- a/src/resampling.jl
+++ b/src/resampling.jl
@@ -215,6 +215,41 @@ end
 StratifiedCV(; nfolds::Int=6,  shuffle=nothing, rng=nothing) =
        StratifiedCV(nfolds, shuffle_and_rng(shuffle, rng)...)
 
+# Description of the stratified CV algorithm:
+#
+# There are algorithms that are conceptually somewhat simpler than this
+# algorithm, but this algorithm is O(n) and is invariant to relabelling
+# of the target vector.
+#
+# 1) Use countmap() to get the count for each level.
+#
+# 2) Use unique() to get the order in which the levels appear. (Steps 1
+# and 2 could be combined if countmap() used an OrderedDict.)
+#
+# 3) For y = ['b', 'c', 'a', 'b', 'b', 'b', 'c', 'c', 'c', 'a', 'a', 'a'],
+# the levels occur in the order ['b', 'c', 'a'], and each level has a count
+# of 4. So imagine a table like this:
+#
+# b b b b c c c c a a a a
+# 1 2 3 1 2 3 1 2 3 1 2 3
+#
+# This table ensures that the levels are smoothly spread across the test folds.
+# In other words, where one level leaves off, the next level picks up. So,
+# for example, as the 'c' levels are encountered, the corresponding row indices
+# are added to folds [2, 3, 1, 2], in that order. The vector [1, 2, 3, 1, ...]
+# is stored in `fold_lookup`. And a dictionary `fold_lookup_index_lookup` is
+# created that maps a level to the current location (index) in `fold_lookup`
+# for that level.
+#
+# 4) Iterate i from 1 to length(rows). For each i, look up the corresponding
+# y-level, i.e. y[rows[i]]. Then use `fold_lookup_index_lookup` to look up
+# the current index for that level in `fold_lookup` (and then increment that
+# index). Finally, using that index, use `fold_lookup` to find the test fold
+# in which to put the i-th element of `rows`.
+#
+# 5) Concatenate the appropriate test folds together to get the train
+# indices for each `(train, test)` pair.
+
 function train_test_pairs(stratified_cv::StratifiedCV, rows, y)
 
     st = scitype(y)

--- a/src/resampling.jl
+++ b/src/resampling.jl
@@ -244,7 +244,10 @@ function train_test_pairs(stratified_cv::StratifiedCV, rows, y)
     # For each level, the index of fold_lookup where you start looking.
     initial_lookup_indices = 1 .+ cumsum([0; level_count[1:end-1]])
 
-    lookup_indices = LittleDict(y_levels .=> initial_lookup_indices)
+    # This name looks complicated, but it's the most accurate I could come
+    # up with. Given the y-level of the current row, use this dictionary to
+    # look up the index that you will use to look up the fold in `fold_lookup`.
+    fold_lookup_index_lookup = LittleDict(y_levels .=> initial_lookup_indices)
 
     folds = [Int[] for _ in 1:n_folds]
     for fold in folds
@@ -254,10 +257,10 @@ function train_test_pairs(stratified_cv::StratifiedCV, rows, y)
     for i in 1:n_obs
         level = y_included[i]
 
-        lookup_index = lookup_indices[level]
-        lookup_indices[level] = lookup_index + 1
+        fold_lookup_index = fold_lookup_index_lookup[level]
+        fold_lookup_index_lookup[level] = fold_lookup_index + 1
 
-        fold_index = fold_lookup[lookup_index]
+        fold_index = fold_lookup[fold_lookup_index]
         push!(folds[fold_index], rows[i])
     end
 

--- a/test/composition/arrows.jl
+++ b/test/composition/arrows.jl
@@ -31,12 +31,12 @@ using Random
 
     fit!(ŷ, rows=train)
 
-    @test isapprox(rms(ŷ(rows=test), ys(rows=test)), 0.627123, rtol=1e-4)
+    @test isapprox(rms(ŷ(rows=test), ys(rows=test)), 0.627123, atol=0.07)
 
     # shortcut to get and set hyperparameters of a node
     ẑ[:lambda] = 5.0
     fit!(ŷ, rows=train)
-    @test isapprox(rms(ŷ(rows=test), ys(rows=test)), 0.62699, rtol=1e-4)
+    @test isapprox(rms(ŷ(rows=test), ys(rows=test)), 0.62699, atol=0.07)
 end
 
 @testset "Auto-source" begin

--- a/test/operations.jl
+++ b/test/operations.jl
@@ -1,0 +1,21 @@
+module TestOperations
+
+using Test
+using MLJBase
+using ..Models
+
+@testset "errors for deserialized machines" begin
+    filename = joinpath(@__DIR__, "machine.jlso")
+    m = machine(filename)
+    @test_throws ArgumentError predict(m)
+end
+
+@testset "error for operations on nodes" begin
+    X = source()
+    m = machine(OneHotEncoder(), X)
+    @test_throws ArgumentError transform(m)
+end
+
+end
+
+true

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -71,6 +71,10 @@ end
     VERSION ≥ v"1.3.0-" && @test include("composition/arrows.jl")
 end
 
+@testset "operations.jl" begin
+    @test include("operations.jl")
+end
+
 @testset "hyperparam" begin
     @test include("hyperparam/one_dimensional_ranges.jl")
     @test include("hyperparam/one_dimensional_range_methods.jl")


### PR DESCRIPTION
Fixes #248.

Benchmark between `dev` and this PR:

```julia
using BenchmarkTools

scv = StratifiedCV(nfolds=5);
N = 10_000_000;
rows = 1:(10N);
y = (
    vcat(fill(:a, N), fill(:b, 2N), fill(:c, 3N), fill(:d, 4N))
    |> shuffle
    |> categorical
);

@btime MLJBase.train_test_pairs_old($scv, $rows, $y);
#  14.767 s (1259 allocations: 21.88 GiB)

@btime MLJBase.train_test_pairs_new($scv, $rows, $y);
#  8.020 s (146 allocations: 4.84 GiB)
```