### PR TITLE
clean up and correct export 

### DIFF
--- a/src/MLJBase.jl
+++ b/src/MLJBase.jl
@@ -96,8 +96,7 @@ export coerce, coerce!, autotype, schema, info
 # -------------------------------------------------------------------
 # exports from MLJBase
 
-export DeterministicNetwork, ProbabilisticNetwork, UnsupervisedNetwork,
-       best, @load
+export DeterministicNetwork, ProbabilisticNetwork, UnsupervisedNetwork, @load
 
 # computational_resources.jl:
 export default_resource
@@ -109,8 +108,7 @@ export ParamRange, NumericRange, NominalRange, iterator, scale
 export params # note this is *not* an extension of StatsBase.params
 
 # data.jl:
-export reconstruct, levels_seen, container_type,
-       partition, unpack, complement, restrict, corestrict
+export partition, unpack, complement, restrict, corestrict
 
 # utilities.jl:
 export @set_defaults, flat_values, recursive_setproperty!,
@@ -121,10 +119,6 @@ export HANDLE_GIVEN_ID, @more, @constant, color_on, color_off
 
 # distributions.jl:
 export average
-
-# tasks.jl:
-export SupervisedTask, UnsupervisedTask, MLJTask,
-       X_and_y, X_, y_, nfeatures
 
 # info_dict.jl:
 export info_dict


### PR DESCRIPTION
clean up & export `StaticTransformer` correctly (MLJ.jl re-exports this, but it's currently just an undefined)

closes https://github.com/alan-turing-institute/MLJ.jl/issues/518