### PR TITLE
no explicit MLJBase requirementfor creating @pipeline

### DIFF
--- a/src/composition/composites.jl
+++ b/src/composition/composites.jl
@@ -398,8 +398,9 @@ function from_network_(modl, modeltype_ex, fieldname_exs, model_exs,
     # code defining the composite model struct and fit method:
     program1 = quote
 
-        import MLJBase
-        import MLJModelInterface
+        $(isdefined(modl, :MLJ) ? :(import MLJ.MLJBase) : :(import MLJBase))
+        $(isdefined(modl, :MLJ) ? :(import MLJ.MLJBase.MLJModelInterface) :
+            :(import MLJBase.MLJModelInterface))
 
         mutable struct $modeltype_ex <: MLJBase.$kind
             $(fieldname_exs...)


### PR DESCRIPTION
kinda same as https://github.com/alan-turing-institute/MLJModels.jl/pull/246

This PR allows end users to create `@pipeline`s without adding MLJBase.jl and MLJModelInterface.jl in their enviroments.
`@pipeline` would just work after `using MLJ`, while testing for this package doesn't require it.