### PR TITLE
replace unsafe use of dict in Multithreaded code.

### DIFF
--- a/src/MLJBase.jl
+++ b/src/MLJBase.jl
@@ -227,7 +227,6 @@ const Vec = AbstractVector
 
 const MMI = MLJModelInterface
 const FI  = MLJModelInterface.FullInterface
-const EVALUATE_THRESHOLD = 50
 # ===================================================================
 # Computational Resource
 # default_resource allows to switch the mode of parallelization

--- a/src/MLJBase.jl
+++ b/src/MLJBase.jl
@@ -227,7 +227,7 @@ const Vec = AbstractVector
 
 const MMI = MLJModelInterface
 const FI  = MLJModelInterface.FullInterface
-
+const EVALUATE_THRESHOLD = 50
 # ===================================================================
 # Computational Resource
 # default_resource allows to switch the mode of parallelization

--- a/src/resampling.jl
+++ b/src/resampling.jl
@@ -699,11 +699,7 @@ function evaluate!(mach::Machine, resampling, weights,
      if acceleration isa CPUThreads
         if acceleration.settings === nothing 
             nthreads = Threads.nthreads()
-            #Tasks have some ovehead so tried to avoid excessive creation
-             # set default threshold at 50
-            n = div(nfolds, EVALUATE_THRESHOLD)
-            # The parameter passes as input to CPUThreads is the ntasks
-            acceleration = CPUThreads(n >= nthreads ? nthreads : max(1, n))
+            acceleration = CPUThreads(nthreads)
         end
         acceleration.settings > 0 || 
                 throw(error("Can't create $(acceleration.settings) tasks)"))

--- a/src/resampling.jl
+++ b/src/resampling.jl
@@ -701,7 +701,7 @@ function evaluate!(mach::Machine, resampling, weights,
             nthreads = Threads.nthreads()
             #Tasks have some ovehead so tried to avoid excessive creation
              # set default threshold at 50
-            n = div(nfolds, 50)
+            n = div(nfolds, EVALUATE_THRESHOLD)
             # The parameter passes as input to CPUThreads is the ntasks
             acceleration = CPUThreads(n >= nthreads ? nthreads : max(1, n))
         end

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -295,6 +295,7 @@ function unwind(iterators...)
     return A
 end
 
+
 """
     chunks(range, n)
 split a given range into `n` subranges of approximately equal length.
@@ -333,6 +334,5 @@ function Base.iterate(itr::Chunks{<:AbstractRange}, state=(1,itr.rem))
                 length(itr.range))
    return @inbounds itr.range[first(state):r], (r + 1, rem-1)
 end
-
 
 

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -294,3 +294,45 @@ function unwind(iterators...)
     end
     return A
 end
+
+"""
+    chunks(range, n)
+split a given range into `n` subranges of approximately equal length.
+
+### Example
+```julia
+julia> collect(chunks(1:5, 2))
+2-element Array{UnitRange{Int64},1}:
+ 1:3
+ 4:5
+
+```
+"""
+function chunks(c::AbstractRange, n::Integer)
+    n < 1 && throw(ArgumentError("cannot split range into $n subranges"))
+    return Chunks(c, divrem(length(c), Int(n))...)
+end
+
+struct Chunks{T <: AbstractRange}
+    range::T
+    div::Int
+    rem::Int
+end
+
+Base.eltype(::Type{Chunks{T}}) where {T <: AbstractRange} = T
+
+function Base.length(itr::Chunks{<:AbstractRange})
+   l = length(itr.range)
+   return itr.div == 0 ? l : div(l - itr.rem, itr.div)
+end
+
+function Base.iterate(itr::Chunks{<:AbstractRange}, state=(1,itr.rem))
+    first(state) > length(itr.range) && return nothing
+    rem = last(state)
+    r = min(first(state) + itr.div - (rem > 0 ? 0 : 1),
+                length(itr.range))
+   return @inbounds itr.range[first(state):r], (r + 1, rem-1)
+end
+
+
+

--- a/test/resampling.jl
+++ b/test/resampling.jl
@@ -30,11 +30,13 @@ end
         nmeasures = 2
         func(mach, k) = (sleep(0.01*rand()); fill(1:k, nmeasures))
     end
-
-    machines = Dict(1 => machine(ConstantRegressor(), X, y))
+    mach = machine(ConstantRegressor(), X, y)
     p = Progress(nfolds, dt=0)
-    result = MLJBase._evaluate!(func, machines, accel, nfolds, 1)
-
+    if accel isa CPUThreads
+    result = MLJBase._evaluate!(func, mach, CPUThreads(Threads.nthreads()), nfolds, 1)
+    else
+       result = MLJBase._evaluate!(func, mach, accel, nfolds, 1)
+    end 
     @test result ==
         [1:1, 1:1, 1:2, 1:2, 1:3, 1:3, 1:4, 1:4, 1:5, 1:5, 1:6, 1:6]
 

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -98,5 +98,17 @@ end
     default_resource(CPU1())
 end
 
+@static if VERSION >= v"1.3.0-DEV.573"
+@testset "Chunks" begin 
+    nthreads = Threads.nthreads()
+    #test for cases with exactly same work as threads
+    @test length(MLJBase.chunks(1:nthreads, nthreads)) == nthreads
+    #test for cases with more work than threads
+    @test length(MLJBase.chunks(1:nthreads + rand(1:nthreads), nthreads)) == nthreads
+    #test for cases with less work than threads
+    @test length(MLJBase.chunks(1:nthreads-1, nthreads)) == nthreads - 1
+end
+end
+
 end # module
 true


### PR DESCRIPTION
Closes issue #300 .
### Further Additions in this PR include
1. `CPUThreads` now accepts an (Optional) integer (e.g `CPUThreads(5)` ) which can be used to control the number of threads that are spawned (as spawning threads has some overhead). Most times the default parameters do the trick.
2. A `Chunks` iterator is implemented to help (1) above.
3. The return values of `_evaluate` method now has the right type (You could check this if you like)

## A slight Note on the use of theses Computational Resources in the `evaluate` method
1. `CPU1()` can be used in all cases
2. when using `CPUThreads(n) or CPUThreads()` speed up is only present if the data is small and model involves heavy computations. The package implementing the code for the model must be thread safe. The magnitude of the speedup depends on the number of threads.
3. when using `CPUProcesses` speed up is only present if the data is small and model involves heavy computations. 
   .