### PR TITLE
avoid Unboxing and mem alloc 

### DIFF
--- a/src/resampling.jl
+++ b/src/resampling.jl
@@ -755,7 +755,7 @@ function evaluate!(mach::Machine, resampling, weights,
     per_observation = map(1:nmeasures) do k
         m = measures[k]
         if reports_each_observation(m)
-            [measurements_matrix[:,k]...]
+            measurements_matrix[:,k]
         else
             missing
         end
@@ -767,7 +767,7 @@ function evaluate!(mach::Machine, resampling, weights,
         if reports_each_observation(m)
             broadcast(MLJBase.aggregate, per_observation[k], [m,])
         else
-            [measurements_matrix[:,k]...]
+            measurements_matrix[:,k]
         end
     end
 

--- a/src/resampling.jl
+++ b/src/resampling.jl
@@ -453,9 +453,10 @@ resampling strategies. If `resampling` is not an object of type
 
 gives two-fold cross-validation using the first 200 rows of data.
 
-The resampling strategy is applied repeatedly if `repeats > 1`. For
-`resampling = CV(nfolds=5)`, for example, this generates a total of
-`5n` test folds for evaluation and subsequent aggregation.
+The resampling strategy is applied repeatedly (Monte Carlo resampling)
+if `repeats > 1`. For example, if `repeats = 10`, then `resampling =
+CV(nfolds=5, shuffle=true)`, generates a total of 50 `(train, test)`
+pairs for evaluation and subsequent aggregation.
 
 If `resampling isa MLJ.ResamplingStrategy` then one may optionally
 restrict the data used in evaluation by specifying `rows`.


### PR DESCRIPTION
currently the current implementation boxes `channels` and `progressmeter` (because of the way they are defined and later used in closures passed to `mapreduce`) . This PR fixes that. 
Also the previous code does `[measurements_matrix[:,k]...]` which has unnecessary allocations (@ablaom is there any reason for this). I replaced with `measurements_matrix[:,k]` which has same behaviour(i.e creates a copy)
```julia
julia> A = permutedims(reshape(rand(100), (1,100)));
julia> @btime [$(A)[:,1]...]
  3.491 μs (102 allocations: 3.31 KiB)
julia> @btime $(A)[:,1]
  184.344 ns (1 allocation: 896 bytes)
```