### PR TITLE
create a model for each thread

### DIFF
--- a/src/resampling.jl
+++ b/src/resampling.jl
@@ -664,7 +664,7 @@ function _evaluate!(func, mach, accel::CPUThreads, nfolds, verbosity)
                         end
       
     #One tmach for each task:
-    machines = [mach, [machine(mach.model, mach.args...) for _ in 2:length(partitions)]...]  
+    machines = [mach, [machine(deepcopy(mach.model), mach.args...) for _ in 2:length(partitions)]...]  
    @sync for (i, parts) in enumerate(partitions)    
      Threads.@spawn begin
        results[i] = mapreduce(vcat, parts) do k  

--- a/src/resampling.jl
+++ b/src/resampling.jl
@@ -662,9 +662,9 @@ function _evaluate!(func, mach, accel::CPUThreads, nfolds, verbosity)
                                 ProgressMeter.updateProgress!(p)
                               end
                         end
-      
-    #One tmach for each task:
-    machines = [mach, [machine(deepcopy(mach.model), mach.args...) for _ in 2:length(partitions)]...]  
+   clean!(mach.model)
+   #One tmach for each task:
+   machines = [mach, [machine(mach.model, mach.args...) for _ in 2:length(partitions)]...]  
    @sync for (i, parts) in enumerate(partitions)    
      Threads.@spawn begin
        results[i] = mapreduce(vcat, parts) do k  


### PR DESCRIPTION
The current implementation of `_evaluate!(func, mach, accel::CPUThreads, nfolds, verbosity` shares the state of `mach.model` across all threads. 
But the call to the`fit!` method from `_evaluate` calls `clean!(model)` which mutates the model(a shared state) on each thread causing data race(due to reading and writing from different threads). This so far hasn't caused any issues but there's no telling what would happen when more threads are used. Hence informing the decision to create a clone of the model on each thread(I really still don't like copying)
Another option is to maybe to call the `clean!` method outside the threads (To clean up) so subsequent calls to `clean` within `Threads.@spawn` would only be reading (provided mutation doesn't occur on a previously cleaned model i.e it depends on the user's implementation of `clean(model)` ) but not writing hence avoiding any possible data race.

The first option is a more general solution since it is independent of the users implementation of `clean(model)`
@ablaom Thoughts.