### PR TITLE
Tweaks to @node macro to make it usable outside global scope

### DIFF
--- a/test/composition/learning_networks/nodes.jl
+++ b/test/composition/learning_networks/nodes.jl
@@ -323,21 +323,23 @@ end
 
 end
 
-# cannot be in @testset block:
-X1 = source(4)
-X2 = source(5)
-X = source(1:10)
+@testset "@node" begin
+    X1 = source(4)
+    X2 = source(5)
+    X = source(1:10)
 
-add(a, b, c) = a + b + c
-N = @node add(X1, 1, X2)
-@test N() == 10
+    add(a, b, c) = a + b + c
+    N = @node add(X1, 1, X2)
+    @test N() == 10
 
-N = @node tuple(X1, 5, X1)
-@test N() == (4, 5, 4)
+    N = @node tuple(X1, 5, X1)
+    @test N() == (4, 5, 4)
 
-Y = @node selectrows(X, 3:4)
-@test Y() == 3:4
-@test Y([:one, :two, :three, :four]) == [:three, :four]
+    Y = @node selectrows(X, 3:4)
+    @test Y() == 3:4
+    @test Y([:one, :two, :three, :four]) == [:three, :four]
+
+end
 
 end
 


### PR DESCRIPTION
Currently `@node f(node, not_a_node)` spits the dummy if `node` or `not_a_node` are not defined in global scope. This PR fixes this by assuming anything not in global scope is an `AbstractNode`. 

So, for example, the tests for this macro, which previously failed if wrapped in a `@testset` block, now pass. 

For cases where even this does not work, the user still has the `node` *function*. 

Here's the revised doc-string:

---



    @node f(...)

Construct a new node that applies the function `f` to some combination
of nodes, sources and other arguments.

*Important.* An argument not in global scope is assumed to be a node
 or source.

### Examples

```
X = source(π)
W = @node sin(X)
julia> W()
0

X = source(1:10)
Y = @node selectrows(X, 3:4)
julia> Y()
3:4

julia> Y([:one, :two, :three, :four])
2-element Array{Symbol,1}:
 :three
 :four

X1 = source(4)
X2 = source(5)
add(a, b, c) = a + b + c
N = @node add(X1, 1, X2)
julia> N()
10

```

See also [`node`](@ref)