### PR TITLE
Hyphens are replaced by underscores in column names from OpenML

### DIFF
--- a/src/openml.jl
+++ b/src/openml.jl
@@ -61,7 +61,7 @@ function convert_ARFF_to_rowtable(response)
             if line[1:1] != "%"
                 d = []
                 if occursin("@attribute", lowercase(line))
-                    push!(featureNames, replace(split(line, " ")[2], "'" => ""))
+                    push!(featureNames, replace(replace(split(line, " ")[2], "'" => ""), "-" => "_"))
                     push!(dataTypes, split(line, " ")[3])
                 elseif occursin("@relation", lowercase(line))
                     nothing


### PR DESCRIPTION
Column names with hyphens are replaced with underscores in datasets from OpenML.

Resolves https://github.com/alan-turing-institute/MLJ.jl/issues/579