### PR TITLE
Dump deprecation predict rows

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MLJBase"
 uuid = "a7f614a8-145f-11e9-1d2a-a57a1082229d"
 authors = ["Anthony D. Blaom <anthony.blaom@gmail.com>"]
-version = "0.14.2"
+version = "0.14.3"
 
 [deps]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"

--- a/src/operations.jl
+++ b/src/operations.jl
@@ -32,12 +32,12 @@ for operation in OPERATIONS
         ex = quote
             # 0. operations on machs, given empty data:
             function $(operation)(mach::Machine; rows=:)
-                Base.depwarn("`$($operation)(mach)` and "*
-                             "`$($operation)(mach, rows=...)` are "*
-                             "deprecated. Data or nodes "*
-                             "should be explictly specified, "*
-                             "as in `$($operation)(mach, X)`. ",
-                             Base.Core.Typeof($operation).name.mt.name)
+                # Base.depwarn("`$($operation)(mach)` and "*
+                #              "`$($operation)(mach, rows=...)` are "*
+                #              "deprecated. Data or nodes "*
+                #              "should be explictly specified, "*
+                #              "as in `$($operation)(mach, X)`. ",
+                #              Base.Core.Typeof($operation).name.mt.name)
                 if isempty(mach.args) # deserialized machine with no data
                     throw(ArgumentError("Calling $($operation) on a "*
                                         "deserialized machine with no data "*

--- a/test/composition/models/deprecated.jl
+++ b/test/composition/models/deprecated.jl
@@ -1,4 +1,4 @@
-module TestPipelines
+module TestDeprecated
 
 using MLJBase
 using ..Models
@@ -46,8 +46,10 @@ hand_built = N();
 
 # test a simple pipeline prediction agrees with prediction of
 # hand-built learning network built earlier:
-p = @pipeline(Pipe(sel=FeatureSelector(), knn=KNNRegressor(),
+p = @pipeline(Pipe(sel=FeatureSelector(),
+                   knn=KNNRegressor(),
                    target=UnivariateStandardizer()))
+
 p.knn.K = 3; p.sel.features = [:x3,]
 mach = machine(p, X, y)
 fit!(mach)
@@ -150,4 +152,3 @@ mach  = machine(p99, X) |> fit!
 
 end
 true
-

--- a/test/operations.jl
+++ b/test/operations.jl
@@ -7,18 +7,19 @@ using ..Models
 @testset "errors for deserialized machines" begin
     filename = joinpath(@__DIR__, "machine.jlso")
     m = machine(filename)
-    @test_deprecated @test_throws ArgumentError predict(m)
+#    @test_deprecated @test_throws ArgumentError predict(m)
+     @test_throws ArgumentError predict(m)
 end
 
 @testset "error for operations on nodes" begin
     X = rand(4)
     m = machine(UnivariateStandardizer(), X) |> fit!
     @test_throws ArgumentError inverse_transform(m)
-    @test_deprecated transform(m)
+#    @test_deprecated transform(m)
     X = source(rand(4))
     m = machine(UnivariateStandardizer(), X) |> fit!
     @test_throws ArgumentError inverse_transform(m)
-    @test_deprecated transform(m)
+#    @test_deprecated transform(m)
 end
 
 end


### PR DESCRIPTION
This PR reverts the behaviour of `predict` and other operations when provided `rows=...` keyword. In latest minor release this triggers a dep warning. 

There had been some objections to removing this syntax and on further review it seems we can live with this.

