### PR TITLE
Eliminate multiple entries for `implement_methods` trait

### DIFF
--- a/src/interface/model_api.jl
+++ b/src/interface/model_api.jl
@@ -33,7 +33,7 @@ predict_median(m, fitresult, Xnew, ::Val{<:BadMedianTypes}) =
 
 # not in MLJModelInterface as methodswith requires InteractiveUtils
 MLJModelInterface.implemented_methods(::FI, M::Type{<:MLJType}) =
-    getfield.(methodswith(M), :name)
+    getfield.(methodswith(M), :name) |> unique
 
 # serialization fallbacks:
 # Here `file` can be `String` or `IO` (eg, `file=IOBuffer()`).


### PR DESCRIPTION
```julia
using MLJ
julia> implemented_methods(UnivariateStandardizer())
6-element Array{Symbol,1}:
 :fit              
 :fitted_params    
 :inverse_transform
 :inverse_transform
 :transform        
 :transform      
```

The corresponding entries in model registry will require an MLJModels registry `@update` and new MLJModels patch.