### PR TITLE
Add logpdf method for UnivariateFinite

### DIFF
--- a/src/MLJBase.jl
+++ b/src/MLJBase.jl
@@ -225,7 +225,7 @@ export TruePositive, TrueNegative, FalsePositive, FalseNegative,
 # re-export from Random, StatsBase, Statistics, Distributions,
 # CategoricalArrays, InvertedIndices:
 export pdf, sampler, mode, median, mean, shuffle!, categorical, shuffle,
-       levels, levels!, std, Not, support
+       levels, levels!, std, Not, support, logpdf
 
 
 # ===================================================================

--- a/src/MLJBase.jl
+++ b/src/MLJBase.jl
@@ -46,7 +46,7 @@ import StatsBase
 import StatsBase: fit!, mode, countmap
 import Missings: levels
 import Distributions
-import Distributions: pdf, sampler
+import Distributions: pdf, logpdf, sampler
 const Dist = Distributions
 
 # from Standard Library:

--- a/src/univariate_finite/arrays.jl
+++ b/src/univariate_finite/arrays.jl
@@ -104,6 +104,7 @@ for func in [:pdf, :logpdf]
             return ret
         end
     end)
+end
 
 
 

--- a/src/univariate_finite/arrays.jl
+++ b/src/univariate_finite/arrays.jl
@@ -102,7 +102,7 @@ function Distributions.pdf(
 end
 
 
-## PERFORMANT BROADCASTING OF pdf
+## PERFORMANT BROADCASTING OF pdf and logpdf
 
 # u - a UnivariateFiniteArray
 # cv - a CategoricalValue
@@ -117,6 +117,23 @@ function Base.Broadcast.broadcasted(
     cv in classes(u) || _err_missing_class(cv)
 
     return get(u.prob_given_ref, int(cv), zeros(P, size(u)))
+end
+
+# logpdf.(u, cv)
+function Base.Broadcast.broadcasted(
+    ::typeof(logpdf),
+    u::UniFinArr{S,V,R,P,N},
+    cv::CategoricalValue) where {S,V,R,P,N}
+
+    # Start with the pdf
+    result = pdf.(u,cv)
+
+    # Take the long of each entry in-place
+    @simd for j in eachindex(result)
+        @inbounds result[j] = log(result[j])
+    end
+
+    return result
 end
 
 # pdf.(u, v)

--- a/src/univariate_finite/methods.jl
+++ b/src/univariate_finite/methods.jl
@@ -216,6 +216,7 @@ Other similar methods are available too:
     rand(d, 5) # CategoricalArray{String,1,UInt32}["maybe", "no", "maybe", "maybe", "no"] or similar
     d = fit(UnivariateFinite, v)
     pdf(d, "maybe") # 0.25
+    logpdf(d, "maybe") # log(0.25)
 
 One can also do weighted fits:
 
@@ -236,6 +237,10 @@ function Distributions.pdf(
     class = pool[get(pool, c)]
     return pdf(d, class)
 end
+
+Distributions.logpdf(d::UnivariateFinite, cv::CategoricalValue) = log(pdf(d,cv))
+
+Distributions.logpdf(d::UnivariateFinite{S,V,R,P}, c::V) where {S,V,R,P} = log(pdf(d,c))
 
 function Distributions.mode(d::UnivariateFinite)
     dic = d.prob_given_ref

--- a/test/univariate_finite/arrays.jl
+++ b/test/univariate_finite/arrays.jl
@@ -3,7 +3,7 @@ module TestUnivariateFiniteArray
 using Test
 using MLJBase
 using CategoricalArrays
-import Distributions:pdf, support
+import Distributions:pdf, logpdf, support
 import Distributions
 using StableRNGs
 import Random

--- a/test/univariate_finite/methods.jl
+++ b/test/univariate_finite/methods.jl
@@ -3,7 +3,7 @@ module TestUnivariateFiniteMethods
 using Test
 using MLJBase
 using CategoricalArrays
-import Distributions:pdf, support
+import Distributions:pdf, logpdf, support
 import Distributions
 using StableRNGs
 import Random

--- a/test/univariate_finite/methods.jl
+++ b/test/univariate_finite/methods.jl
@@ -35,6 +35,13 @@ A, S, Q, F = V[1], V[2], V[3], V[4]
     @test pdf(d, f) ≈ 0.7
     @test pdf(d, 'f') ≈ 0.7
     @test pdf(d, a) ≈ 0.0
+    @test logpdf(d, s) ≈ log(0.1)
+    @test logpdf(d, 's') ≈ log(0.1)
+    @test logpdf(d, q) ≈ log(0.2)
+    @test logpdf(d, 'q') ≈ log(0.2)
+    @test logpdf(d, f) ≈ log(0.7)
+    @test logpdf(d, 'f') ≈ log(0.7)
+    @test isinf(logpdf(d, a))
     @test mode(d) == f
 
     @test UnivariateFinite(support(d), [0.7, 0.2, 0.1]) ≈ d
@@ -73,6 +80,13 @@ A, S, Q, F = V[1], V[2], V[3], V[4]
     @test pdf(d, F) ≈ 0.7
     @test pdf(d, 'f') ≈ 0.7
     @test pdf(d, A) ≈ 0.0
+    @test logpdf(d, S) ≈ log(0.1)
+    @test logpdf(d, 's') ≈ log(0.1)
+    @test logpdf(d, Q) ≈ log(0.2)
+    @test logpdf(d, 'q') ≈ log(0.2)
+    @test logpdf(d, F) ≈ log(0.7)
+    @test logpdf(d, 'f') ≈ log(0.7)
+    @test isinf(logpdf(d, A))
     @test mode(d) == F
 
     @test UnivariateFinite(support(d), [0.7, 0.2, 0.1]) ≈ d


### PR DESCRIPTION
Take 2!

This just adds a `logpdf` method and some tests. `logpdf` is needed for MCMC sampling with SossMLJ: https://github.com/cscherrer/SossMLJ.jl/issues/68