### PR TITLE
added logpdf.(u, v) and logpdf.(u, raw) methods

### DIFF
--- a/src/univariate_finite/arrays.jl
+++ b/src/univariate_finite/arrays.jl
@@ -167,7 +167,7 @@ end
 # logpdf.(u, cv)
 # logpdf.(u, v)
 # logpdf.(u, raw)
-for typ in [:CategoricalValue, :AbstractArray{<:CategoricalValue{V,R},N}, :Union{V,AbstractArray{V,N}}]
+for typ in [:CategoricalValue, :(AbstractArray{<:CategoricalValue{V,R},N}), :(Union{V,AbstractArray{V,N}})]
  eval(quote function Base.Broadcast.broadcasted(
          ::typeof(logpdf),
          u::UniFinArr{S,V,R,P,N},

--- a/src/univariate_finite/arrays.jl
+++ b/src/univariate_finite/arrays.jl
@@ -176,7 +176,7 @@ for typ in [:CategoricalValue, :(AbstractArray{<:CategoricalValue{V,R},N}), :(Un
         # Start with the pdf
         result = pdf.(u,cv)
 
-        # Take the long of each entry in-place
+        # Take the log of each entry in-place
         @simd for j in eachindex(result)
             @inbounds result[j] = log(result[j])
         end

--- a/src/univariate_finite/arrays.jl
+++ b/src/univariate_finite/arrays.jl
@@ -173,12 +173,15 @@ for typ in [:CategoricalValue, :(AbstractArray{<:CategoricalValue{V,R},N}), :(Un
          u::UniFinArr{S,V,R,P,N},
          cv::$typ) where {S,V,R,P,N}
 
-        # Start with the pdf
-        result = pdf.(u,cv)
-
+        # Start with the pdf array
+        pdf_arr = pdf.(u,cv)
+        
+        # Create an uninitialized array similar to pdf_arr
+        # this avoids mutating the initial pdf_arr 
+	result = similar(pdf_arr)
         # Take the log of each entry in-place
         @simd for j in eachindex(result)
-            @inbounds result[j] = log(result[j])
+            @inbounds result[j] = log(pdf_arr[j])
         end
 
         return result

--- a/test/univariate_finite/arrays.jl
+++ b/test/univariate_finite/arrays.jl
@@ -92,33 +92,49 @@ end
 n = 10
 P = rand(n);
 all_classes = categorical([:no, :yes], ordered=true)
-u = UnivariateFinite(all_classes, P, augment=true)
+u = UnivariateFinite(all_classes, P, augment=true) #uni_fin_arr
 
 # next is not specific to `UnivariateFiniteArray` but is for any
 # abstract array with eltype `UnivariateFinite`:
-@testset "piratical pdf" begin
+@testset "piratical pdf and logpdf" begin
+    # test pdf(uni_fin_arr, labels) and
+    # logpdf(uni_fin_arr, labels)
     @test pdf(u, [:yes, :no]) == hcat(P, 1 .- P)
+    @test isequal(logpdf(u, [:yes, :no]), log.(hcat(P, 1 .- P)))
     @test pdf(u, reverse(all_classes)) == hcat(P, 1 .- P)
+    @test isequal(logpdf(u, reverse(all_classes)), log.(hcat(P, 1 .- P)))
+    
+    # test pdf(::Array{UnivariateFinite, 1}, labels) and
+    # logpdf(::Array{UnivariateFinite, labels)
     @test pdf([u...], [:yes, :no]) == hcat(P, 1 .- P)
+    @test isequal(logpdf([u...], [:yes, :no]), log.(hcat(P, 1 .- P)))
     @test pdf([u...], all_classes) == hcat(1 .- P, P)
+    @test isequal(logpdf([u...], all_classes), log.(hcat(1 .- P, P)))
 end
 
-@testset "broadcasting: pdf.(uni_fin_arr, scalar) " begin
+@testset "broadcasting: pdf.(uni_fin_arr, scalar) and logpdf.(uni_fin_arr, scalar) " begin
     @test pdf.(u,:yes) == P
+    @test isequal(logpdf.(u,:yes), log.(P))
     @test pdf.(u,all_classes[2]) == P
+    @test isequal(logpdf.(u,all_classes[2]), log.(P))
 
     # check unseen probablities are a zero *array*:
     v = categorical(1:4)
     probs = rand(3)
     u2 = UnivariateFinite(v[1:2], probs, augment=true)
     @test pdf.(u2, v[3]) == zeros(3)
+    @test isequal(logpdf.(u2, v[3]), log.(zeros(3)))
 end
 
-@testset "broadcasting: pdf.(uni_fin_arr, array_same_shape)" begin
+@testset "broadcasting: pdf.(uni_fin_arr, array_same_shape) and logpdf.(uni_fin_arr, array_same_shape)" begin
     v = rand(classes(u), n)
     @test broadcast(pdf, u, v) == [pdf(u[i], v[i]) for i in 1:length(u)]
+    @test isequal(broadcast(logpdf, u, v), 
+        [logpdf(u[i], v[i]) for i in 1:length(u)])
     @test broadcast(pdf, u, get.(v)) ==
         [pdf(u[i], v[i]) for i in 1:length(u)]
+    @test isequal(broadcast(logpdf, u, get.(v)), 
+        [logpdf(u[i], v[i]) for i in 1:length(u)])
 end
 
 @testset "broadcasting: check indexing in `getter((cv, i), dtype)` see PR#375" begin


### PR DESCRIPTION
I feel that PR #411 left out some methods. I feel these methods are needed since we want `logpdf` to have similar functionality with `pdf` the difference being just the `log`.
So this PR Adds `logpdf.(u::UniFinArr{S,V,R,P,N}, v::AbstractArray{<:CategoricalValue{V,R},N})` and 
 `logpdf.(u::UniFinArr{S,V,R,P,N}, raw::Union{V,AbstractArray{V,N}})` methods.

Feel free to close this if u feel these method are not needed.