### PR TITLE
Support Distributions 0.24

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MLJBase"
 uuid = "a7f614a8-145f-11e9-1d2a-a57a1082229d"
 authors = ["Anthony D. Blaom <anthony.blaom@gmail.com>"]
-version = "0.15.2"
+version = "0.15.3"
 
 [deps]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"
@@ -32,7 +32,7 @@ Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 [compat]
 CategoricalArrays = "^0.8.1"
 ComputationalResources = "^0.3"
-Distributions = "^0.22,^0.23"
+Distributions = "0.22, 0.23, 0.24"
 HTTP = "^0.8"
 InvertedIndices = "^1"
 JLSO = "^2.1,^2.2"

--- a/src/univariate_finite/methods.jl
+++ b/src/univariate_finite/methods.jl
@@ -198,6 +198,14 @@ function _pdf(d::UnivariateFinite{S,V,R,P}, ref) where {S,V,R,P}
     return get(d.prob_given_ref, ref, zero(P))
 end
 
+function _pdf(d::UnivariateFinite{S,V}, c::V) where {S,V}
+    _classes = classes(d)
+    c in _classes || throw(DomainError("Value $c not in pool. "))
+    pool = CategoricalArrays.pool(_classes)
+    class = pool[get(pool, c)]
+    return pdf(d, class)
+end
+
 """
     Distributions.pdf(d::UnivariateFinite, x)
 
@@ -227,20 +235,12 @@ One can also do weighted fits:
 See also `classes`, `support`.
 """
 Distributions.pdf(d::UnivariateFinite, cv::CategoricalValue) = _pdf(d, int(cv))
-
-function Distributions.pdf(
-    d::UnivariateFinite{S,V,R,P}, c::V) where {S,V,R,P}
-
-    _classes = classes(d)
-    c in _classes || throw(DomainError("Value $c not in pool. "))
-    pool = CategoricalArrays.pool(_classes)
-    class = pool[get(pool, c)]
-    return pdf(d, class)
-end
+Distributions.pdf(d::UnivariateFinite{S,V}, c::V) where {S,V} = _pdf(d, c)
+Distributions.pdf(d::UnivariateFinite{S,V}, c::V) where {S,V<:Real} = _pdf(d, c)
 
 Distributions.logpdf(d::UnivariateFinite, cv::CategoricalValue) = log(pdf(d,cv))
-
-Distributions.logpdf(d::UnivariateFinite{S,V,R,P}, c::V) where {S,V,R,P} = log(pdf(d,c))
+Distributions.logpdf(d::UnivariateFinite{S,V}, c::V) where {S,V} = log(pdf(d, c))
+Distributions.logpdf(d::UnivariateFinite{S,V}, c::V) where {S,V<:Real} = log(pdf(d, c))
 
 function Distributions.mode(d::UnivariateFinite)
     dic = d.prob_given_ref

--- a/src/univariate_finite/methods.jl
+++ b/src/univariate_finite/methods.jl
@@ -193,19 +193,6 @@ function average(dvec::AbstractVector{UnivariateFinite{S,V,R,P}};
     return UnivariateFinite(sample_scitype(d1), d1.decoder, prob_given_ref)
 end
 
-
-function _pdf(d::UnivariateFinite{S,V,R,P}, ref) where {S,V,R,P}
-    return get(d.prob_given_ref, ref, zero(P))
-end
-
-function _pdf(d::UnivariateFinite{S,V}, c::V) where {S,V}
-    _classes = classes(d)
-    c in _classes || throw(DomainError("Value $c not in pool. "))
-    pool = CategoricalArrays.pool(_classes)
-    class = pool[get(pool, c)]
-    return pdf(d, class)
-end
-
 """
     Distributions.pdf(d::UnivariateFinite, x)
 
@@ -234,12 +221,29 @@ One can also do weighted fits:
 
 See also `classes`, `support`.
 """
-Distributions.pdf(d::UnivariateFinite, cv::CategoricalValue) = _pdf(d, int(cv))
+function Distributions.pdf(
+    d::UnivariateFinite{S,V,R,P},
+    cv::CategoricalValue,
+) where {S,V,R,P}
+    return get(d.prob_given_ref, int(cv), zero(P))
+end
 Distributions.pdf(d::UnivariateFinite{S,V}, c::V) where {S,V} = _pdf(d, c)
+
+# Avoid method ambiguity errors with Distributions >= 0.24
 Distributions.pdf(d::UnivariateFinite{S,V}, c::V) where {S,V<:Real} = _pdf(d, c)
+
+function _pdf(d::UnivariateFinite, c)
+    _classes = classes(d)
+    c in _classes || throw(DomainError("Value $c not in pool. "))
+    pool = CategoricalArrays.pool(_classes)
+    class = pool[get(pool, c)]
+    return pdf(d, class)
+end
 
 Distributions.logpdf(d::UnivariateFinite, cv::CategoricalValue) = log(pdf(d,cv))
 Distributions.logpdf(d::UnivariateFinite{S,V}, c::V) where {S,V} = log(pdf(d, c))
+
+# Avoid method ambiguity errors with Distributions >= 0.24
 Distributions.logpdf(d::UnivariateFinite{S,V}, c::V) where {S,V<:Real} = log(pdf(d, c))
 
 function Distributions.mode(d::UnivariateFinite)

--- a/test/univariate_finite/methods.jl
+++ b/test/univariate_finite/methods.jl
@@ -222,6 +222,11 @@ end
     @test pdf(d, 'f') == 0
     @test pdf(d, f) == 0
     @test_throws DomainError pdf(d, 'j')
+
+    # regression test
+    # https://github.com/alan-turing-institute/MLJBase.jl/pull/432/files#r502299301
+    d = UnivariateFinite(classes(categorical(UInt32[0, 1])), [0.4, 0.6])
+    @test pdf(d, UInt32(1)) == 0.6
 end
 
 @testset "approx for UnivariateFinite" begin


### PR DESCRIPTION
The changes in Distributions 0.24 (more precisely, https://github.com/JuliaStats/Distributions.jl/pull/1171) require some additional dispatches to avoid method ambiguity errors (as seen e.g. in https://github.com/alan-turing-institute/MLJBase.jl/pull/431).

This PR supersedes https://github.com/alan-turing-institute/MLJBase.jl/pull/431.