### PR TITLE
Multiclass 3

### DIFF
--- a/src/MLJBase.jl
+++ b/src/MLJBase.jl
@@ -253,9 +253,9 @@ export MulticlassTruePositive, MulticlassTrueNegative, MulticlassFalsePositive,
 
 # -------------------------------------------------------------------
 # re-export from Random, StatsBase, Statistics, Distributions,
-# CategoricalArrays, InvertedIndices:
+# OrderedCollections, CategoricalArrays, InvertedIndices:
 export pdf, sampler, mode, median, mean, shuffle!, categorical, shuffle,
-       levels, levels!, std, Not, support, logpdf
+       levels, levels!, std, Not, support, logpdf, LittleDict
 
 
 # ===================================================================

--- a/src/MLJBase.jl
+++ b/src/MLJBase.jl
@@ -197,10 +197,10 @@ export cross_entropy, BrierScore, brier_score,
        balanced_accuracy, bacc, bac,
        matthews_correlation, mcc
 
-# measures/finite.jl -- binary order independent:
+# measures/finite.jl -- Multiclass{2} (order independent):
 export auc, area_under_curve, roc_curve, roc
 
-# measures/finite.jl -- binary order dependent:
+# measures/finite.jl -- OrderedFactor{2} (order dependent):
 export TruePositive, TrueNegative, FalsePositive, FalseNegative,
        TruePositiveRate, TrueNegativeRate, FalsePositiveRate,
        FalseNegativeRate, FalseDiscoveryRate, Precision, NPV, FScore,
@@ -220,35 +220,36 @@ export TruePositive, TrueNegative, FalsePositive, FalseNegative,
        recall, sensitivity, hit_rate, miss_rate,
        specificity, selectivity, f1score, fallout
 
-# measures/finite.jl -- multiclass generalizations of above (but order
-# independent):
+# measures/finite.jl -- Finite{N} - multiclass generalizations of
+# above OrderedFactor{2} measures (but order independent):
 export MulticlassTruePositive, MulticlassTrueNegative, MulticlassFalsePositive,
-       MulticlassFalseNegative, MulticlassTruePositiveRate,
-       MulticlassTrueNegativeRate, MulticlassFalsePositiveRate,
-       MulticlassFalseNegativeRate, MulticlassFalseDiscoveryRate,
-       MulticlassPrecision, MulticlassNPV, MulticlassFScore,
-       # standard synonyms
-       MTPR, MTNR, MFPR, MFNR, MFDR, MPPV,
-       MulticlassRecall, MulticlassSpecificity,
-       # instances and their synonyms
-       multiclass_truepositive, multiclass_truenegative, multiclass_falsepositive,
-       multiclass_falsenegative, multiclass_true_positive,
-       multiclass_true_negative, multiclass_false_positive,
-       multiclass_false_negative, multiclass_truepositive_rate,
-       multiclass_truenegative_rate, multiclass_falsepositive_rate,
-       multiclass_true_positive_rate, multiclass_true_negative_rate,
-       multiclass_false_positive_rate, multiclass_falsenegative_rate,
-       multiclass_negativepredictive_value, multiclass_false_negative_rate,
-       multiclass_negative_predictive_value, multiclass_positivepredictive_value,
-       multiclass_positive_predictive_value, multiclass_tpr, multiclass_tnr,
-       multiclass_fpr, multiclass_fnr, multiclass_falsediscovery_rate,
-       multiclass_false_discovery_rate, multiclass_fdr, multiclass_npv,
-       multiclass_ppv, multiclass_recall, multiclass_sensitivity,
-       multiclass_hit_rate, multiclass_miss_rate, multiclass_specificity,
-       multiclass_selectivity, macro_f1score, micro_f1score,
-       multiclass_f1score, multiclass_fallout, multiclass_precision,
-       # averaging modes
-       macro_avg, micro_avg
+      MulticlassFalseNegative, MulticlassTruePositiveRate,
+      MulticlassTrueNegativeRate, MulticlassFalsePositiveRate,
+      MulticlassFalseNegativeRate, MulticlassFalseDiscoveryRate,
+      MulticlassPrecision, MulticlassNPV, MulticlassFScore,
+      # standard synonyms
+      MTPR, MTNR, MFPR, MFNR, MFDR, MPPV,
+      MulticlassRecall, MulticlassSpecificity,
+      # instances and their synonyms
+      multiclass_truepositive, multiclass_truenegative,
+      multiclass_falsepositive,
+      multiclass_falsenegative, multiclass_true_positive,
+      multiclass_true_negative, multiclass_false_positive,
+      multiclass_false_negative, multiclass_truepositive_rate,
+      multiclass_truenegative_rate, multiclass_falsepositive_rate,
+      multiclass_true_positive_rate, multiclass_true_negative_rate,
+      multiclass_false_positive_rate, multiclass_falsenegative_rate,
+      multiclass_negativepredictive_value, multiclass_false_negative_rate,
+      multiclass_negative_predictive_value, multiclass_positivepredictive_value,
+      multiclass_positive_predictive_value, multiclass_tpr, multiclass_tnr,
+      multiclass_fpr, multiclass_fnr, multiclass_falsediscovery_rate,
+      multiclass_false_discovery_rate, multiclass_fdr, multiclass_npv,
+      multiclass_ppv, multiclass_recall, multiclass_sensitivity,
+      multiclass_hit_rate, multiclass_miss_rate, multiclass_specificity,
+      multiclass_selectivity, macro_f1score, micro_f1score,
+      multiclass_f1score, multiclass_fallout, multiclass_precision,
+      # averaging modes
+      no_avg, macro_avg, micro_avg
 
 # -------------------------------------------------------------------
 # re-export from Random, StatsBase, Statistics, Distributions,

--- a/src/MLJBase.jl
+++ b/src/MLJBase.jl
@@ -226,7 +226,7 @@ export MulticlassTruePositive, MulticlassTrueNegative, MulticlassFalsePositive,
       MulticlassFalseNegative, MulticlassTruePositiveRate,
       MulticlassTrueNegativeRate, MulticlassFalsePositiveRate,
       MulticlassFalseNegativeRate, MulticlassFalseDiscoveryRate,
-      MulticlassPrecision, MulticlassNPV, MulticlassFScore,
+      MulticlassPrecision, MulticlassNegativePredictiveValue, MulticlassFScore,
       # standard synonyms
       MTPR, MTNR, MFPR, MFNR, MFDR, MPPV,
       MulticlassRecall, MulticlassSpecificity,

--- a/src/measures/finite.jl
+++ b/src/measures/finite.jl
@@ -878,16 +878,24 @@ const CM = ConfusionMatrix{N} where N
 abstract type MulticlassAvg end
 struct MacroAvg <: MulticlassAvg end
 struct MicroAvg <: MulticlassAvg end
+struct NoAvg <: MulticlassAvg end
 
 const macro_avg = MacroAvg()
 const micro_avg = MicroAvg()
+const no_avg    = NoAvg()
 
-const DS_AVG_RET = "The `average` can be specified as `micro_avg` or " *
-                   "`macro_avg` (default). "*
-                   "The `return_type` can be "*
-                   "`LittleDict`(default) or `AbstractVector`. "
-const CLASS_W    = "An optional `AbstractDict`, `class_w`, keyed on "*
-    "`levels(y)`, specifies class weights. "
+const DS_AVG_RET = "Options for `average` are: `no_avg`, `macro_avg` "*
+    "(default) and `micro_avg`. Options for `return_type`, "*
+    "applying in the `no_avg` case, are: `LittleDict`(default) or "*
+    "`AbstractVector`. "
+
+const DS_RET = "Options `return_type` are: "*
+    "`LittleDict`(default) or "*
+    "`AbstractVector`. "
+
+const CLASS_W = "An optional `AbstractDict`, denoted `class_w` above, "*
+    "keyed on `levels(y)`, specifies class weights. It applies only if "*
+    "`average=macro_avg`."
 
 """
     MulticlassFScore(; β=1.0, average=macro_avg, return_type=LittleDict)
@@ -899,8 +907,7 @@ multiclass observations.
     MulticlassFScore()(ŷ, y, class_w)
 
 Evaluate the default score on multiclass observations, `ŷ`, given
-ground truth values, `y`. The `average` can be specified as
-`micro_avg` or `macro_avg` (default). $CLASS_W
+ground truth values, `y`. $DS_AVG_RET (default). $CLASS_W
 
 For more information, run `info(MulticlassFScore)`.
 
@@ -910,9 +917,6 @@ struct MulticlassFScore{M<:MulticlassAvg, U<:Union{Vec, LittleDict}} <:Measure
     average::M
     return_type::Type{U}
 end
-
-MulticlassFScore(β, average::M, return_type::Type{U}) where {M, U} =
-    MulticlassFScore{M,U}(β, average, return_type)
 
 MulticlassFScore(; β=1.0, average=macro_avg, return_type=LittleDict) =
     MulticlassFScore(β, average, return_type)
@@ -926,19 +930,34 @@ metadata_measure(MulticlassFScore;
     supports_weights         = false,
     supports_class_weights   = true)
 
-MLJModelInterface.name(::Type{<:MulticlassFScore{β}}) where β = "MulticlassFScore{$β}"
-MLJModelInterface.name(::Type{MulticlassFScore})        = "MulticlassFScore" # for registry
-MLJModelInterface.docstring(::Type{<:MulticlassFScore}) = "Multiclass F_β score; aliases: " *
-        "`macro_f1score=MulticlassFScore{1}`, `multiclass_f1score=MulticlassFScore{1}`" *
-        "`MulticlassFScore{β}`, `micro_f1score=MulticlassFScore(; β=1.0, average=micro_avg)`."
+MLJModelInterface.docstring(::Type{<:MulticlassFScore}) =
+    "Multiclass F_β score; aliases: " *
+    "`macro_f1score=MulticlassFScore()`, "*
+    "`multiclass_f1score=MulticlassFScore(average=no_avg)` " *
+    "`micro_f1score=MulticlassFScore(average=micro_avg)`."
 
 const micro_f1score      = MulticlassFScore(average=micro_avg)
-const macro_f1score      = MulticlassFScore()
-const multiclass_f1score = macro_f1score
+const macro_f1score      = MulticlassFScore(average=macro_avg)
+const multiclass_f1score = MulticlassFScore(average=no_avg)
 
 for M in (:MulticlassTruePositive, :MulticlassTrueNegative,
-          :MulticlassFalsePositive, :MulticlassFalseNegative,
-          :MulticlassTruePositiveRate, :MulticlassTrueNegativeRate,
+          :MulticlassFalsePositive, :MulticlassFalseNegative)
+    ex = quote
+        struct $M{U<:Union{Vec, LittleDict}} <: Measure
+            return_type::Type{U}
+        end
+#        $M(return_type::Type{U}) where {U} = $M(return_type)
+        $M(; return_type=LittleDict) = $M(return_type)
+    end
+    eval(ex)
+end
+
+const _mtp_vec = MulticlassTruePositive(return_type=Vec)
+const _mfn_vec = MulticlassFalseNegative(return_type=Vec)
+const _mfp_vec = MulticlassFalsePositive(return_type=Vec)
+const _mtn_vec = MulticlassTrueNegative(return_type=Vec)
+
+for M in (:MulticlassTruePositiveRate, :MulticlassTrueNegativeRate,
           :MulticlassFalsePositiveRate, :MulticlassFalseNegativeRate,
           :MulticlassFalseDiscoveryRate, :MulticlassPrecision, :MulticlassNPV)
     ex = quote
@@ -946,7 +965,9 @@ for M in (:MulticlassTruePositive, :MulticlassTrueNegative,
             average::T
             return_type::Type{U}
         end
-        $M(average::T, return_type::Type{U}) where {T, U} = $M(average, return_type)
+        # @ablaom says next line looks redundant:
+        $M(average::T, return_type::Type{U}) where {T, U} =
+            $M(average, return_type)
         $M(; average=macro_avg,
            return_type=LittleDict) where T<:MulticlassAvg where
            U<:Union{Vec, LittleDict} = $M(average, return_type)
@@ -1003,75 +1024,77 @@ metadata_measure.((MulticlassTruePositiveRate, MulticlassPrecision);
     supports_class_weights   = true)
 
 # MMI.name(::Type{<:MulticlassTruePositive})       = "multiclass_true_positive"
-MMI.docstring(::Type{<:MulticlassTruePositive})  = "Number of true positives; " *
-                "aliases: `multiclass_true_positive`, `multiclass_truepositive`."
+MMI.docstring(::Type{<:MulticlassTruePositive})  =
+    "Number of true positives; " *
+    "aliases: `multiclass_true_positive`, `multiclass_truepositive`."
 # MMI.name(::Type{<:MulticlassTrueNegative})       = "multiclass_true_negative"
-MMI.docstring(::Type{<:MulticlassTrueNegative})  = "Number of true negatives; " *
-                "aliases: `multiclass_true_negative`, `multiclass_truenegative`."
+MMI.docstring(::Type{<:MulticlassTrueNegative})  =
+    "Number of true negatives; " *
+    "aliases: `multiclass_true_negative`, `multiclass_truenegative`."
 # MMI.name(::Type{<:MulticlassFalsePositive})      = "multiclass_false_positive"
-MMI.docstring(::Type{<:MulticlassFalsePositive}) = "Number of false positives; " *
-                "aliases: `multiclass_false_positive`, `multiclass_falsepositive`."
+MMI.docstring(::Type{<:MulticlassFalsePositive}) =
+    "Number of false positives; " *
+    "aliases: `multiclass_false_positive`, `multiclass_falsepositive`."
 # MMI.name(::Type{<:MulticlassFalseNegative})      = "multiclass_false_negative"
-MMI.docstring(::Type{<:MulticlassFalseNegative}) = "Number of false negatives; " *
-                "aliases: `multiclass_false_negative`, `multiclass_falsenegative`."
+MMI.docstring(::Type{<:MulticlassFalseNegative}) =
+    "Number of false negatives; " *
+    "aliases: `multiclass_false_negative`, `multiclass_falsenegative`."
 
 # MMI.name(::Type{<:MulticlassTruePositiveRate}) = "multiclass_true_positive_rate"
 MMI.docstring(::Type{<:MulticlassTruePositiveRate}) =
-                    "multiclass true positive rate; aliases: " *
-                    "`multiclass_true_positive_rate`, `multiclass_tpr`, " *
-                    "`multiclass_sensitivity`, `multiclass_recall`, " *
-                    "`multiclass_hit_rate`, `multiclass_truepositive_rate`, " *
-                    "`multiclass_recall=MulticlassRecall(; average=macro_avg, return_type=LittleDict)`."
+    "multiclass true positive rate; aliases: " *
+    "`multiclass_true_positive_rate`, `multiclass_tpr`, " *
+    "`multiclass_sensitivity`, `multiclass_recall`, " *
+    "`multiclass_hit_rate`, `multiclass_truepositive_rate`, "
 # MMI.name(::Type{<:MulticlassTrueNegativeRate}) = "multiclass_true_negative_rate"
 MMI.docstring(::Type{<:MulticlassTrueNegativeRate}) =
-                        "multiclass true negative rate; aliases: " *
-                       "`multiclass_true_negative_rate`, `multiclass_tnr` " *
-                       " `multiclass_specificity`, `multiclass_selectivity`, " *
-                       "`multiclass_truenegative_rate`."
+    "multiclass true negative rate; aliases: " *
+    "`multiclass_true_negative_rate`, `multiclass_tnr` " *
+    " `multiclass_specificity`, `multiclass_selectivity`, " *
+    "`multiclass_truenegative_rate`."
 # MMI.name(::Type{<:MulticlassFalsePositiveRate}) = "multiclass_false_positive_rate"
 MMI.docstring(::Type{<:MulticlassFalsePositiveRate}) =
-                        "multiclass false positive rate; aliases: " *
+                       "multiclass false positive rate; aliases: " *
                        "`multiclass_false_positive_rate`, `multiclass_fpr` " *
                        "`multiclass_fallout`, `multiclass_falsepositive_rate`."
 # MMI.name(::Type{<:MulticlassFalseNegativeRate}) = "multiclass_false_negative_rate"
 MMI.docstring(::Type{<:MulticlassFalseNegativeRate}) =
-                        "multiclass false negative rate; aliases: " *
-                       "`multiclass_false_negative_rate`, `multiclass_fnr`, " *
-                       "`multiclass_miss_rate`, `multiclass_falsenegative_rate`."
+    "multiclass false negative rate; aliases: " *
+    "`multiclass_false_negative_rate`, `multiclass_fnr`, " *
+    "`multiclass_miss_rate`, `multiclass_falsenegative_rate`."
 # MMI.name(::Type{<:MulticlassFalseDiscoveryRate}) = "multiclass_false_discovery_rate"
 MMI.docstring(::Type{<:MulticlassFalseDiscoveryRate}) =
-                        "multiclass false discovery rate; "*
-                       "aliases: `multiclass_false_discovery_rate`, " *
-                       "`multiclass_falsediscovery_rate`, `multiclass_fdr`."
+    "multiclass false discovery rate; "*
+    "aliases: `multiclass_false_discovery_rate`, " *
+    "`multiclass_falsediscovery_rate`, `multiclass_fdr`."
 # MMI.name(::Type{<:MulticlassNPV}) = "multiclass_negative_predictive_value"
 MMI.docstring(::Type{<:MulticlassNPV}) =
-                        "multiclass negative predictive value; aliases: " *
-                       "`multiclass_negative_predictive_value`, " *
-                       "`multiclass_negativepredictive_value`, `multiclass_npv`."
+    "multiclass negative predictive value; aliases: " *
+    "`multiclass_negative_predictive_value`, " *
+    "`multiclass_negativepredictive_value`, `multiclass_npv`."
 # MMI.name(::Type{<:MulticlassPrecision}) = "multiclass_positive_predictive_value"
 MMI.docstring(::Type{<:MulticlassPrecision}) =
   "multiclass positive predictive value (aka precision);"*
   " aliases: `multiclass_positive_predictive_value`, `multiclass_ppv`, " *
-  "`MulticlassPrecision()`, `multiclass_positivepredictive_value` " *
-  "`multiclass_recall=MulticlassPrecision(; average=macro_avg, return_type=LittleDict)`."
+  "`MulticlassPrecision()`, `multiclass_positivepredictive_value`, " *
+  "`multiclass_recall`."
 
 const W_KEY_MISMATCH = "Encountered target with levels different from the " *
                        "keys of user-specified dictionary of class weights."
-const W_PROMOTE_WARN = "As `class_w` specifies the weights for each class, " *
-                       "promoting average to `macro_avg`."
-
+const W_PROMOTE_WARN = "Using macro averaging instead of micro averaging, as "*
+    "class weights specified. "
 
 """
-    MulticlassTruePositive(; average=macro_avg, return_type=LittleDict)
+    MulticlassTruePositive(; return_type=LittleDict)
 
 $(docstring(MulticlassTruePositive()))
 
     MulticlassTruePositive()(ŷ, y)
 
 Number of true positives for multiclass observations `ŷ` and ground
-truth `y`, using default averaging and return type. $DS_AVG_RET
+truth `y`, using default return type. $DS_RET
 
-For more information, run `info(multiclass_true_positive)`.
+For more information, run `info(MulticlassTruePositive)`.
 
 """
 const multiclass_true_positive  = MulticlassTruePositive()
@@ -1079,33 +1102,34 @@ const multiclass_truepositive   = MulticlassTruePositive()
 const mtp = MulticlassTruePositive()
 
 """
-    MulticlassTrueNegative(; average=macro_avg, return_type=LittleDict)
+    MulticlassTrueNegative(; return_type=LittleDict)
 
 $(docstring(MulticlassTrueNegative()))
 
     MulticlassTrueNegative()(ŷ, y)
 
 Number of true negatives for multiclass observations `ŷ` and ground truth
-`y`, using default averaging and return type. $DS_AVG_RET 
+`y`, using default return type. $DS_RET
 
-For more information, run `info(multiclass_true_negative)`.
+For more information, run `info(MulticlassTrueNegative)`.
 
 """
 const multiclass_true_negative  = MulticlassTrueNegative()
 const multiclass_truenegative   = MulticlassTrueNegative()
 const mtn = MulticlassTrueNegative()
 
+
 """
-  MulticlassFalsePositive(; average=macro_avg, return_type=LittleDict)
+    MulticlassFalsePositive(; return_type=LittleDict)
 
 $(docstring(MulticlassFalsePositive()))
 
-  MulticlassFalsePositive()(ŷ, y)
+    MulticlassFalsePositive()(ŷ, y)
 
-Number of false positives for multiclass observations `ŷ` and ground truth
-`y`, using default averaging and return type. $DS_AVG_RET 
+Number of false positives for multiclass observations `ŷ` and ground
+truth `y`, using default return type. $DS_RET
 
-For more information, run `info(multiclass_false_positive)`.
+For more information, run `info(MulticlassFalsePositive)`.
 
 """
 const multiclass_false_positive = MulticlassFalsePositive()
@@ -1113,16 +1137,16 @@ const multiclass_falsepositive  = MulticlassFalsePositive()
 const mfp = MulticlassFalsePositive()
 
 """
-    MulticlassFalseNegative
+    MulticlassFalseNegative(; return_type=LittleDict)
 
 $(docstring(MulticlassFalseNegative()))
 
     MulticlassFalseNegative()(ŷ, y)
 
-Number of false positives for multiclass observations `ŷ` and ground
-truth `y`, using default averaging and return type. $DS_AVG_RET
+Number of false negatives for multiclass observations `ŷ` and ground
+truth `y`, using default return type. $DS_RET
 
-For more information, run `info(multiclass_false_negative)`.
+For more information, run `info(MulticlassFalseNegative)`.
 
 """
 const multiclass_false_negative = MulticlassFalseNegative()
@@ -1137,10 +1161,11 @@ $(docstring(MulticlassTruePositiveRate()))
     MulticlassTruePositiveRate(ŷ, y)
     MulticlassTruePositiveRate(ŷ, y, class_w)
 
-True positive rate for multiclass observations `ŷ` and ground truth
-`y`, using default averaging and return type. $DS_AVG_RET $CLASS_W
+True positive rate (a.k.a. sensitivity, recall, hit rate) for
+multiclass observations `ŷ` and ground truth `y`, using default
+averaging and return type. $DS_AVG_RET $CLASS_W
 
-For more information, run `info(multiclass_true_positive_rate)`.
+For more information, run `info(MulticlassTruePositiveRate)`.
 
 """
 const multiclass_true_positive_rate = MulticlassTruePositiveRate()
@@ -1149,19 +1174,6 @@ const multiclass_tpr                = MulticlassTruePositiveRate()
 const multiclass_sensitivity        = MulticlassTruePositiveRate()
 const multiclass_hit_rate           = MulticlassTruePositiveRate()
 const MTPR                          = MulticlassTruePositiveRate
-
-"""
-   MulticlassRecall(; average=macro_avg, return_type=LittleDict)
-
-   MulticlassRecall()(ŷ, y)
-   MulticlassRecall()(ŷ, y, class_w)
-
-Recall for multiclass observations `ŷ` and ground truth `y`, using
-default averaging and return type.  $DS_AVG_RET $CLASS_W
-
-For more information, run `info(MulticlassRecall)`.
-
-"""
 const multiclass_recall             = MulticlassTruePositiveRate()
 const MulticlassRecall              = MulticlassTruePositiveRate
 
@@ -1176,7 +1188,7 @@ $(docstring(MulticlassTrueNegativeRate()))
 True negative rate for multiclass observations `ŷ` and ground truth
 `y`, using default averaging and return type. $DS_AVG_RET $CLASS_W
 
-For more information, run `info(multiclass_true_negative_rate)`.
+For more information, run `info(MulticlassTrueNegativeRate)`.
 
 """
 const multiclass_true_negative_rate = MulticlassTrueNegativeRate()
@@ -1198,13 +1210,13 @@ $(docstring(MulticlassFalsePositiveRate()))
 False positive rate for multiclass observations `ŷ` and ground truth
 `y`, using default averaging and return type.  $DS_AVG_RET $CLASS_W
 
-For more information, run `info(multiclass_false_positive_rate)`.
+For more information, run `info(MulticlassFalsePositiveRate)`.
 
 """
 const multiclass_false_positive_rate = MulticlassFalsePositiveRate()
 const multiclass_falsepositive_rate  = MulticlassFalsePositiveRate()
 const multiclass_fpr                 = MulticlassFalsePositiveRate()
- const MFPR                           = MulticlassFalsePositiveRate
+const MFPR                           = MulticlassFalsePositiveRate
 const multiclass_fallout             = MFPR()
 
 """
@@ -1218,7 +1230,7 @@ $(docstring(MulticlassFalseNegativeRate()))
 False negative rate for multiclass observations `ŷ` and ground truth
 `y`, using default averaging and return type.  $DS_AVG_RET $CLASS_W
 
-For more information, run `info(multiclass_false_negative_rate)`.
+For more information, run `info(MulticlassFalseNegativeRate)`.
 
 """
 const multiclass_false_negative_rate = MulticlassFalseNegativeRate()
@@ -1230,7 +1242,7 @@ const multiclass_miss_rate           = MFNR()
 """
     MulticlassFalseDiscoveryRate(; average=macro_avg, return_type=LittleDict)
 
-$(docstring(MulticlassTruePositiveRate()))
+$(docstring(MulticlassFalseDiscoveryRate()))
 
     MulticlassFalseDiscoveryRate()(ŷ, y)
     MulticlassFalseDiscoveryRate()(ŷ, y, class_w)
@@ -1238,7 +1250,7 @@ $(docstring(MulticlassTruePositiveRate()))
 False discovery rate for multiclass observations `ŷ` and ground truth
 `y`, using default averaging and return type.  $DS_AVG_RET $CLASS_W
 
-For more information, run `info(multiclass_false_discovery_rate)`.
+For more information, run `info(MulticlassFalseDiscoveryRate)`.
 
 """
 const multiclass_false_discovery_rate = MulticlassFalseDiscoveryRate()
@@ -1266,19 +1278,18 @@ const multiclass_positive_predictive_value = MulticlassPrecision()
 const multiclass_positivepredictive_value  = MulticlassPrecision()
 const MPPV                                 = MulticlassPrecision
 
-
 """
-    MulticlassNegativePredictiveValue(; average=macro_avg, return_type=LittleDict)
+    MulticlassNPV(; average=macro_avg, return_type=LittleDict)
 
 $(docstring(MulticlassNPV()))
 
-    MulticlassNegativePredictiveValue()(ŷ, y)
-    MulticlassNegativePredictiveValue()(ŷ, y, class_w)
+    MulticlassNPV()(ŷ, y)
+    MulticlassNPV()(ŷ, y, class_w)
 
 Negative predictive value for multiclass observations `ŷ` and ground truth
 `y`, using default averaging and return type. $DS_AVG_RET $CLASS_W
 
-For more information, run `info(multiclass_negative_predictive_value)`.
+For more information, run `info(MulticlassNPV)`.
 
 """
 const multiclass_npv                       = MulticlassNPV()
@@ -1289,14 +1300,42 @@ const MNPV                                 = MulticlassNPV
 
 ## INTERNAL FUCNTIONS ON MULTICLASS CONFUSION MATRIX
 
-_mtp(m::CM) = diag(m.mat)
-_mfp(m::CM) = (col_sum = vec(sum(m.mat, dims=2)); col_sum .-= diag(m.mat))
-_mfn(m::CM) = (row_sum = vec(collect(transpose(sum(m.mat, dims=1))));
-               row_sum .-= diag(m.mat))
-function _mtn(m::CM)
+_mtp(m::CM, return_type::Type{Vec}) = diag(m.mat)
+_mtp(m::CM, return_type::Type{LittleDict}) =
+    LittleDict(m.labels, diag(m.mat))
+
+_mfp(m::CM, return_type::Type{Vec}) =
+    (col_sum = vec(sum(m.mat, dims=2)); col_sum .-= diag(m.mat))
+
+_mfp(m::CM, return_type::Type{LittleDict}) =
+    (col_sum = vec(sum(m.mat, dims=2)); col_sum .-= diag(m.mat);
+     LittleDict(m.labels, col_sum))
+
+_mfn(m::CM, return_type::Type{Vec}) =
+    (row_sum = vec(collect(transpose(sum(m.mat, dims=1))));
+     row_sum .-= diag(m.mat))
+
+_mfn(m::CM, return_type::Type{LittleDict}) =
+    (row_sum = vec(collect(transpose(sum(m.mat, dims=1))));
+     row_sum .-= diag(m.mat); LittleDict(m.labels, row_sum))
+
+function _mtn(m::CM, return_type::Type{Vec})
     _sum  = sum(m.mat, dims=2)
     _sum .= sum(m.mat) .- (_sum .+= sum(m.mat, dims=1)'.+ diag(m.mat))
     return vec(_sum)
+end
+
+function _mtn(m::CM, return_type::Type{LittleDict})
+    _sum  = sum(m.mat, dims=2)
+    _sum .= sum(m.mat) .- (_sum .+= sum(m.mat, dims=1)'.+ diag(m.mat))
+    return LittleDict(m.labels, vec(_sum))
+end
+
+@inline function _mean(x::Vec{<:Real})
+    for i in eachindex(x)
+        @inbounds x[i] = ifelse(isnan(x[i]), zero(eltype(x)), x[i])
+    end
+    return mean(x)
 end
 
 @inline function _class_w(level_m::Vec{<:String},
@@ -1307,62 +1346,104 @@ end
 end
 
 @inline function _mc_helper(m::CM, a::Vec{<:Real}, b::Vec{<:Real},
-                            average::MacroAvg, return_type::Type{Vec})
+                            average::NoAvg, return_type::Type{Vec})
     return vec(a ./ (a + b))
 end
 
 @inline function _mc_helper(m::CM, a::Vec{<:Real}, b::Vec{<:Real},
-                            average::MacroAvg, return_type::Type{LittleDict})
+                            average::NoAvg, return_type::Type{LittleDict})
     return LittleDict(m.labels, _mc_helper(m, a, b, average, Vec))
 end
 
 @inline function _mc_helper(m::CM, a::Vec{<:Real}, b::Vec{<:Real},
+                            average::MacroAvg, return_type::Type{U}) where U
+    return _mean(_mc_helper(m, a, b, no_avg, Vec))
+end
+
+@inline function _mc_helper(m::CM, a::Vec{<:Real}, b::Vec{<:Real},
                             average::MicroAvg, return_type::Type{U}) where U
-    a_sum, b_sum = sum(a), sum(b)
+     a_sum, b_sum = sum(a), sum(b)
     return a_sum / (a_sum + b_sum)
 end
 
 @inline function _mc_helper(m::CM, a::Vec{<:Real}, b::Vec{<:Real},
                             class_w::AbstractDict{<:Any, <:Real},
+                            average::NoAvg, return_type::Type{Vec})
+    level_w = _class_w(m.labels, class_w)
+    return _mc_helper(m, a, b, no_avg, return_type) .* level_w
+end
+
+@inline function _mc_helper(m::CM, a::Vec{<:Real}, b::Vec{<:Real},
+                            class_w::AbstractDict{<:Any, <:Real},
                             average::MacroAvg, return_type::Type{Vec})
-    level_w = _class_w(m.labels, class_w)
-    return _mc_helper(m, a, b, macro_avg, return_type) .* level_w
+    return _mean(_mc_helper(m, a, b, class_w, no_avg, return_type))
+end
+
+@inline function _mc_helper(m::CM, a::Vec{<:Real}, b::Vec{<:Real},
+                            class_w::AbstractDict{<:Any, <:Real},
+                            average::MicroAvg, return_type)
+    @warn W_PROMOTE_WARN
+    return _mc_helper(m, a, b, class_w, macro_avg, Vec)
 end
 
 @inline function _mc_helper_b(m::CM, helper_name,
                               class_w::AbstractDict{<:Any, <:Real},
-                              average::MacroAvg, return_type::Type{Vec})
+                              average::NoAvg, return_type::Type{Vec})
     level_w = _class_w(m.labels, class_w)
-    return (1 .- helper_name(m, macro_avg, return_type)) .* level_w
+    return (1 .- helper_name(m, no_avg, return_type)) .* level_w
 end
 
 @inline function _mc_helper_b(m::CM, helper_name,
                               class_w::AbstractDict{<:Any, <:Real},
-                              average::MacroAvg, return_type::Type{LittleDict})
+                              average::NoAvg, return_type::Type{LittleDict})
     level_w = _class_w(m.labels, class_w)
-    return LittleDict(m.labels, (1 .- helper_name(m, macro_avg, Vec)) .* level_w)
+    return LittleDict(m.labels, ((1 .- helper_name(m, no_avg, Vec)) .* level_w))
 end
 
-@inline function _mc_helper_b(m::CM, helper_name, average::MacroAvg,
+@inline function _mc_helper_b(m::CM, helper_name,
+                              class_w::AbstractDict{<:Any, <:Real},
+                              average::MacroAvg, return_type)
+    return _mean(_mc_helper_b(m, helper_name, class_w, no_avg, Vec))
+end
+
+@inline function _mc_helper_b(m::CM, helper_name,
+                              class_w::AbstractDict{<:Any, <:Real},
+                              average::MicroAvg, return_type)
+    @warn W_PROMOTE_WARN
+    return _mc_helper_b(m, helper_name, class_w, macro_avg, Vec)
+end
+
+@inline function _mc_helper_b(m::CM, helper_name, average::NoAvg,
                               return_type::Type{LittleDict})
     return LittleDict(m.labels, 1.0 .- helper_name(m, average, Vec))
 end
 
-@inline function _mc_helper_b(m::CM, helper_name, average::MicroAvg,
-                              return_type::Type{LittleDict})
+@inline function _mc_helper_b(m::CM, helper_name, average::NoAvg,
+                              return_type::Type{Vec})
     return 1.0 .- helper_name(m, average, Vec)
 end
 
-@inline function _mc_helper_b(m::CM, helper_name, average::A,
-                              return_type::Type{Vec}) where A
+@inline function _mc_helper_b(m::CM, helper_name, average::MacroAvg,
+                              return_type)
+    return 1.0 .- helper_name(m, average, Vec)
+end
+
+@inline function _mc_helper_b(m::CM, helper_name, average::MicroAvg,
+                              return_type)
     return 1.0 .- helper_name(m, average, Vec)
 end
 
 @inline function _mc_helper(m::CM, a::Vec{<:Real}, b::Vec{<:Real},
                             class_w::AbstractDict{<:Any, <:Real},
-                            average::MacroAvg, return_type::Type{LittleDict})
+                            average::NoAvg, return_type::Type{LittleDict})
     level_w = _class_w(m.labels, class_w)
-    return LittleDict(m.labels, _mc_helper(m, a, b, class_w, macro_avg, Vec))
+    return LittleDict(m.labels, _mc_helper(m, a, b, class_w, no_avg, Vec))
+end
+
+@inline function _mc_helper(m::CM, a::Vec{<:Real}, b::Vec{<:Real},
+                            class_w::AbstractDict{<:Any, <:Real},
+                            average::MacroAvg, return_type::Type{U}) where U
+    return _mean(_mc_helper(m, a, b, class_w, no_avg, Vec))
 end
 
 @inline function _mc_helper(m::CM, a::Vec{<:Real}, b::Vec{<:Real},
@@ -1373,29 +1454,30 @@ end
 end
 
 function _mtpr(m::CM, average::A, return_type::Type{U}) where {A, U}
-    mtp_val, mfn_val = mtp(m), mfn(m)
-    _mc_helper(m, mtp_val, mfn_val, average, return_type)
+    mtp_val, mfn_val = _mtp_vec(m), _mfn_vec(m)
+    return _mc_helper(m, mtp_val, mfn_val, average, return_type)
 end
 
 function _mtpr(m::CM, class_w::AbstractDict{<:Any, <:Real}, average::A,
                return_type::Type{U}) where {A, U}
-    mtp_val, mfn_val = mtp(m), mfn(m)
-    _mc_helper(m, mtp_val, mfn_val, class_w, average, return_type)
+    mtp_val, mfn_val = _mtp_vec(m), _mfn_vec(m)
+    return _mc_helper(m, mtp_val, mfn_val, class_w, average, return_type)
 end
 
 function _mtnr(m::CM, average::A, return_type::Type{U}) where {A, U}
-    mtn_val, mfp_val = mtn(m), mfp(m)
-    _mc_helper(m, mtn_val, mfp_val, average, return_type)
+    mtn_val, mfp_val = _mtn_vec(m), _mfp_vec(m)
+    return _mc_helper(m, mtn_val, mfp_val, average, return_type)
 end
 
 function _mtnr(m::CM, class_w::AbstractDict{<:Any, <:Real}, average::A,
                return_type::Type{U}) where {A, U}
-    mtn_val, mfp_val = mtn(m), mfp(m)
-    _mc_helper(m, mtn_val, mfp_val, class_w, average, return_type)
+    mtn_val, mfp_val = _mtn_vec(m), _mfp_vec(m)
+    return _mc_helper(m, mtn_val, mfp_val, class_w, average, return_type)
 end
 
 _mfpr(m::CM, average::A, return_type::Type{U}) where {A, U} =
     _mc_helper_b(m, _mtnr, average, return_type)
+
 function _mfpr(m::CM, class_w::AbstractDict{<:Any, <:Real}, average::A,
                return_type::Type{U}) where {A, U}
     return _mc_helper_b(m, _mtnr, class_w, average, return_type)
@@ -1410,126 +1492,144 @@ function _mfnr(m::CM, class_w::AbstractDict{<:Any, <:Real}, average::A,
 end
 
 function _mfdr(m::CM, average::A, return_type::Type{U}) where {A, U}
-    mfp_val, mtp_val = mfp(m), mtp(m)
-    _mc_helper(m, mfp_val, mtp_val, average, return_type)
+    mfp_val, mtp_val = _mfp_vec(m), _mtp_vec(m)
+    return _mc_helper(m, mfp_val, mtp_val, average, return_type)
 end
 
 function _mfdr(m::CM, class_w::AbstractDict{<:Any, <:Real}, average::A,
                return_type::Type{U}) where {A, U}
-    mfp_val, mtp_val = mfp(m), mtp(m)
-    _mc_helper(m, mfp_val, mtp_val, class_w, average, return_type)
+    mfp_val, mtp_val = _mfp_vec(m), _mtp_vec(m)
+    return _mc_helper(m, mfp_val, mtp_val, class_w, average, return_type)
 end
 
 function _mnpv(m::CM, average::A, return_type::Type{U}) where {A, U}
-    mtn_val, mfn_val = mtn(m), mfn(m)
-    _mc_helper(m, mtn_val, mfn_val, average, return_type)
+    mtn_val, mfn_val = _mtn_vec(m), _mfn_vec(m)
+    return _mc_helper(m, mtn_val, mfn_val, average, return_type)
 end
 
 function _mnpv(m::CM, class_w::AbstractDict{<:Any, <:Real}, average::A,
                return_type::Type{U}) where {A, U}
-    mtn_val, mfn_val = mtn(m), mfn(m)
-    _mc_helper(m, mtn_val, mfn_val, class_w, average, return_type)
+    mtn_val, mfn_val = _mtn_vec(m), _mfn_vec(m)
+    return _mc_helper(m, mtn_val, mfn_val, class_w, average, return_type)
 end
 
 ## CALLABLES ON MULTICLASS CONFUSION MATRIX
 
-(::MulticlassTruePositive)(m::CM{N}) where N  = _mtp(m)
-(::MulticlassTrueNegative)(m::CM{N}) where N  = _mtn(m)
-(::MulticlassFalsePositive)(m::CM{N}) where N = _mfp(m)
-(::MulticlassFalseNegative)(m::CM{N}) where N = _mfn(m)
+(p::MulticlassTruePositive)(m::CM)  = _mtp(m, p.return_type)
+(n::MulticlassTrueNegative)(m::CM)  = _mtn(m, n.return_type)
+(p::MulticlassFalsePositive)(m::CM) = _mfp(m, p.return_type)
+(n::MulticlassFalseNegative)(m::CM) = _mfn(m, n.return_type)
 
 (r::MTPR)(m::CM) = _mtpr(m, r.average, r.return_type)
-(r::MTPR)(m::CM, w::AbstractDict{<:Any, <:Real}) = _mtpr(m, w, r.average, r.return_type)
+(r::MTPR)(m::CM, w::AbstractDict{<:Any, <:Real}) =
+    _mtpr(m, w, r.average, r.return_type)
 
 (r::MTNR)(m::CM) = _mtnr(m, r.average, r.return_type)
-(r::MTNR)(m::CM, w::AbstractDict{<:Any, <:Real}) = _mtnr(m, w, r.average, r.return_type)
+(r::MTNR)(m::CM, w::AbstractDict{<:Any, <:Real}) =
+    _mtnr(m, w, r.average, r.return_type)
 
 (r::MFPR)(m::CM) = _mfpr(m, r.average, r.return_type)
-(r::MFPR)(m::CM, w::AbstractDict{<:Any, <:Real}) = _mfpr(m, w, r.average, r.return_type)
+(r::MFPR)(m::CM, w::AbstractDict{<:Any, <:Real}) =
+    _mfpr(m, w, r.average, r.return_type)
 
 (r::MFNR)(m::CM) = _mfnr(m, r.average, r.return_type)
-(r::MFNR)(m::CM, w::AbstractDict{<:Any, <:Real}) = _mfnr(m, w, r.average, r.return_type)
+(r::MFNR)(m::CM, w::AbstractDict{<:Any, <:Real}) =
+    _mfnr(m, w, r.average, r.return_type)
 
 (r::MFDR)(m::CM) = _mfdr(m, r.average, r.return_type)
-(r::MFDR)(m::CM, w::AbstractDict{<:Any, <:Real}) = _mfdr(m, w, r.average, r.return_type)
+(r::MFDR)(m::CM, w::AbstractDict{<:Any, <:Real}) =
+    _mfdr(m, w, r.average, r.return_type)
 
 (v::MNPV)(m::CM) = _mnpv(m, v.average, v.return_type)
-(v::MNPV)(m::CM, w::AbstractDict{<:Any, <:Real}) = _mnpv(m, w, v.average, v.return_type)
+(v::MNPV)(m::CM, w::AbstractDict{<:Any, <:Real}) =
+    _mnpv(m, w, v.average, v.return_type)
 
-(p::MulticlassPrecision)(m::CM) = _mc_helper_b(m, _mfdr, p.average, p.return_type)
+(p::MulticlassPrecision)(m::CM) =
+    _mc_helper_b(m, _mfdr, p.average, p.return_type)
 function (p::MulticlassPrecision)(m::CM, class_w::AbstractDict{<:Any, <:Real})
     return _mc_helper_b(m, _mfdr, class_w, p.average, p.return_type)
 end
 
-@inline function _fs_helper(m::CM, β::Real, rec::Real, prec::Real,
-                            average::MicroAvg, return_type::Type{U}) where U
-    β2 = β^2
-    return (1 + β2) * (prec * rec) / (β* prec + rec)
-end
-
 @inline function _fs_helper(m::CM, β::Real, rec::Vec{<:Real}, prec::Vec{<:Real},
-                    average::MacroAvg, return_type::Type{LittleDict})
+                    average::NoAvg, return_type::Type{LittleDict})
     β2 = β^2
     return LittleDict(m.labels, (1 + β2) .* (prec .* rec) ./ (β2 .* prec .+ rec))
 end
 
 @inline function _fs_helper(m::CM, β::Real, rec::Vec{<:Real}, prec::Vec{<:Real},
-                    average::MacroAvg, return_type::Type{Vec})
+                    average::NoAvg, return_type::Type{Vec})
     β2 = β^2
     return (1 + β2) .* (prec .* rec) ./ (β2 .* prec .+ rec)
 end
 
+@inline function _fs_helper(m::CM, β::Real, rec::Vec{<:Real}, prec::Vec{<:Real},
+                    average::MacroAvg, return_type::Type{U}) where U
+    return _mean(_fs_helper(m, β, rec, prec, no_avg, Vec))
+end
+
+@inline function _fs_helper(m::CM, β::Real, rec::Real, prec::Real,
+                            average::MicroAvg, return_type::Type{U}) where U
+    β2 = β^2
+    return (1 + β2) * (prec * rec) / (β * prec + rec)
+end
+
 function (f::MulticlassFScore)(m::CM)
-    rec  = MulticlassRecall(; average=f.average, return_type=Vec)(m)
     if f.average == micro_avg
+        rec = MulticlassRecall(; average=f.average, return_type=Vec)(m)
         f.β == 1.0 && return rec
         return _fs_helper(m, f.β, rec, rec, f.average, f.return_type)
     end
-    prec = MulticlassPrecision(; average=f.average, return_type=Vec)(m)
+    rec = MulticlassRecall(; average=no_avg, return_type=Vec)(m)
+    prec = MulticlassPrecision(; average=no_avg, return_type=Vec)(m)
     return _fs_helper(m, f.β, rec, prec, f.average, f.return_type)
 end
 
-@inline function _fs_helper(m::CM, w::AbstractDict{<:Real, <:Real}, β::Real,
+@inline function _fs_helper(m::CM, w::AbstractDict{<:Any, <:Real}, β::Real,
+                    average::NoAvg, return_type::Type{LittleDict})
+    level_w = _class_w(m.labels, w)
+    return LittleDict(m.labels,
+                      MulticlassFScore(β=β,
+                                       average=no_avg,
+                                       return_type=Vec)(m) .* level_w)
+end
+
+@inline function _fs_helper(m::CM, w::AbstractDict{<:Any, <:Real}, β::Real,
+                    average::NoAvg, return_type::Type{Vec})
+    level_w = _class_w(m.labels, w)
+    return MulticlassFScore(β=β,
+                            average=no_avg,
+                            return_type=Vec)(m) .* level_w
+end
+
+@inline function _fs_helper(m::CM, w::AbstractDict{<:Any, <:Real}, β::Real,
+                            average::MacroAvg, return_type::Type{U}) where U
+    return _mean(_fs_helper(m, w, β, no_avg, Vec))
+end
+
+@inline function _fs_helper(m::CM, w::AbstractDict{<:Any, <:Real}, β::Real,
                             average::MicroAvg, return_type::Type{U}) where U
     @warn W_PROMOTE_WARN
-    _fs_helper(m, w, β, macro_avg, return_type)
-end
-
-@inline function _fs_helper(m::CM, w::AbstractDict{<:Real, <:Real}, β::Real,
-                    average::MacroAvg, return_type::Type{LittleDict})
-    level_w = _class_w(m.labels, w)
-    return LittleDict(m.labels, MulticlassFScore(β=β, return_type=Vec)(m) .* level_w)
-end
-
-@inline function _fs_helper(m::CM, w::AbstractDict{<:Real, <:Real}, β::Real,
-                    average::MacroAvg, return_type::Type{Vec})
-    level_w = _class_w(m.labels, w)
-    return MulticlassFScore(β=β, return_type=Vec)(m) .* level_w
+    return _fs_helper(m, w, β, macro_avg, return_type)
 end
 
 function (f::MulticlassFScore)(m::CM, class_w::AbstractDict{<:Any, <:Real})
-    _fs_helper(m, class_w, f.β, f.average, f.return_type)
+    return _fs_helper(m, class_w, f.β, f.average, f.return_type)
 end
 
 ## Callables on vectors
 
 for M in (MulticlassTruePositive, MulticlassTrueNegative,
           MulticlassFalsePositive, MulticlassFalseNegative)
-    (m::M)(ŷ, y) = confmat(ŷ, y, warn=false) |> m
+    (m::M)(ŷ, y) = m(confmat(ŷ, y, warn=false))
 end
 
-for M in (MTPR, MTNR, MFPR, MFNR, MFDR, MulticlassPrecision, MNPV)
+for M in (MTPR, MTNR, MFPR, MFNR, MFDR, MulticlassPrecision, MNPV,
+          MulticlassFScore)
     @eval (m::$M)(ŷ, y) = m(confmat(ŷ, y, warn=false))
     @eval (m::$M)(ŷ, y, class_w::AbstractDict{<:Any, <:Real}) =
                           m(confmat(ŷ, y, warn=false), class_w)
 end
 
-(m::MulticlassFScore)(ŷ, y) where β =
-    MulticlassFScore(; average=m.average,
-                     return_type=m.return_type)(confmat(ŷ, y, warn=false))
-(m::MulticlassFScore)(ŷ, y, class_w::AbstractDict{<:Any, <:Real}) where β =
-    MulticlassFScore(; average=m.average,
-                     return_type=m.return_type)(confmat(ŷ, y, warn=false), class_w)
 
 ## ROC COMPUTATION
 

--- a/src/measures/finite.jl
+++ b/src/measures/finite.jl
@@ -886,12 +886,12 @@ const no_avg    = NoAvg()
 
 const DS_AVG_RET = "Options for `average` are: `no_avg`, `macro_avg` "*
     "(default) and `micro_avg`. Options for `return_type`, "*
-    "applying in the `no_avg` case, are: `LittleDict`(default) or "*
-    "`AbstractVector`. "
+    "applying in the `no_avg` case, are: `LittleDict` (default) or "*
+    "`Vector`. "
 
 const DS_RET = "Options `return_type` are: "*
     "`LittleDict`(default) or "*
-    "`AbstractVector`. "
+    "`Vector`. "
 
 const CLASS_W = "An optional `AbstractDict`, denoted `class_w` above, "*
     "keyed on `levels(y)`, specifies class weights. It applies only if "*
@@ -912,7 +912,7 @@ ground truth values, `y`. $DS_AVG_RET (default). $CLASS_W
 For more information, run `info(MulticlassFScore)`.
 
 """
-struct MulticlassFScore{M<:MulticlassAvg, U<:Union{Vec, LittleDict}} <:Measure
+struct MulticlassFScore{M<:MulticlassAvg, U<:Union{Vector, LittleDict}} <:Measure
     β::Float64
     average::M
     return_type::Type{U}
@@ -943,7 +943,7 @@ const multiclass_f1score = MulticlassFScore(average=no_avg)
 for M in (:MulticlassTruePositive, :MulticlassTrueNegative,
           :MulticlassFalsePositive, :MulticlassFalseNegative)
     ex = quote
-        struct $M{U<:Union{Vec, LittleDict}} <: Measure
+        struct $M{U<:Union{Vector, LittleDict}} <: Measure
             return_type::Type{U}
         end
 #        $M(return_type::Type{U}) where {U} = $M(return_type)
@@ -952,16 +952,16 @@ for M in (:MulticlassTruePositive, :MulticlassTrueNegative,
     eval(ex)
 end
 
-const _mtp_vec = MulticlassTruePositive(return_type=Vec)
-const _mfn_vec = MulticlassFalseNegative(return_type=Vec)
-const _mfp_vec = MulticlassFalsePositive(return_type=Vec)
-const _mtn_vec = MulticlassTrueNegative(return_type=Vec)
+const _mtp_vec = MulticlassTruePositive(return_type=Vector)
+const _mfn_vec = MulticlassFalseNegative(return_type=Vector)
+const _mfp_vec = MulticlassFalsePositive(return_type=Vector)
+const _mtn_vec = MulticlassTrueNegative(return_type=Vector)
 
 for M in (:MulticlassTruePositiveRate, :MulticlassTrueNegativeRate,
           :MulticlassFalsePositiveRate, :MulticlassFalseNegativeRate,
           :MulticlassFalseDiscoveryRate, :MulticlassPrecision, :MulticlassNPV)
     ex = quote
-        struct $M{T<:MulticlassAvg, U<:Union{Vec, LittleDict}} <: Measure
+        struct $M{T<:MulticlassAvg, U<:Union{Vector, LittleDict}} <: Measure
             average::T
             return_type::Type{U}
         end
@@ -970,7 +970,7 @@ for M in (:MulticlassTruePositiveRate, :MulticlassTrueNegativeRate,
             $M(average, return_type)
         $M(; average=macro_avg,
            return_type=LittleDict) where T<:MulticlassAvg where
-           U<:Union{Vec, LittleDict} = $M(average, return_type)
+           U<:Union{Vector, LittleDict} = $M(average, return_type)
     end
     eval(ex)
 end
@@ -1300,18 +1300,18 @@ const MNPV                                 = MulticlassNPV
 
 ## INTERNAL FUCNTIONS ON MULTICLASS CONFUSION MATRIX
 
-_mtp(m::CM, return_type::Type{Vec}) = diag(m.mat)
+_mtp(m::CM, return_type::Type{Vector}) = diag(m.mat)
 _mtp(m::CM, return_type::Type{LittleDict}) =
     LittleDict(m.labels, diag(m.mat))
 
-_mfp(m::CM, return_type::Type{Vec}) =
+_mfp(m::CM, return_type::Type{Vector}) =
     (col_sum = vec(sum(m.mat, dims=2)); col_sum .-= diag(m.mat))
 
 _mfp(m::CM, return_type::Type{LittleDict}) =
     (col_sum = vec(sum(m.mat, dims=2)); col_sum .-= diag(m.mat);
      LittleDict(m.labels, col_sum))
 
-_mfn(m::CM, return_type::Type{Vec}) =
+_mfn(m::CM, return_type::Type{Vector}) =
     (row_sum = vec(collect(transpose(sum(m.mat, dims=1))));
      row_sum .-= diag(m.mat))
 
@@ -1319,7 +1319,7 @@ _mfn(m::CM, return_type::Type{LittleDict}) =
     (row_sum = vec(collect(transpose(sum(m.mat, dims=1))));
      row_sum .-= diag(m.mat); LittleDict(m.labels, row_sum))
 
-function _mtn(m::CM, return_type::Type{Vec})
+function _mtn(m::CM, return_type::Type{Vector})
     _sum  = sum(m.mat, dims=2)
     _sum .= sum(m.mat) .- (_sum .+= sum(m.mat, dims=1)'.+ diag(m.mat))
     return vec(_sum)
@@ -1346,18 +1346,18 @@ end
 end
 
 @inline function _mc_helper(m::CM, a::Vec{<:Real}, b::Vec{<:Real},
-                            average::NoAvg, return_type::Type{Vec})
+                            average::NoAvg, return_type::Type{Vector})
     return vec(a ./ (a + b))
 end
 
 @inline function _mc_helper(m::CM, a::Vec{<:Real}, b::Vec{<:Real},
                             average::NoAvg, return_type::Type{LittleDict})
-    return LittleDict(m.labels, _mc_helper(m, a, b, average, Vec))
+    return LittleDict(m.labels, _mc_helper(m, a, b, average, Vector))
 end
 
 @inline function _mc_helper(m::CM, a::Vec{<:Real}, b::Vec{<:Real},
                             average::MacroAvg, return_type::Type{U}) where U
-    return _mean(_mc_helper(m, a, b, no_avg, Vec))
+    return _mean(_mc_helper(m, a, b, no_avg, Vector))
 end
 
 @inline function _mc_helper(m::CM, a::Vec{<:Real}, b::Vec{<:Real},
@@ -1368,14 +1368,14 @@ end
 
 @inline function _mc_helper(m::CM, a::Vec{<:Real}, b::Vec{<:Real},
                             class_w::AbstractDict{<:Any, <:Real},
-                            average::NoAvg, return_type::Type{Vec})
+                            average::NoAvg, return_type::Type{Vector})
     level_w = _class_w(m.labels, class_w)
     return _mc_helper(m, a, b, no_avg, return_type) .* level_w
 end
 
 @inline function _mc_helper(m::CM, a::Vec{<:Real}, b::Vec{<:Real},
                             class_w::AbstractDict{<:Any, <:Real},
-                            average::MacroAvg, return_type::Type{Vec})
+                            average::MacroAvg, return_type::Type{Vector})
     return _mean(_mc_helper(m, a, b, class_w, no_avg, return_type))
 end
 
@@ -1383,12 +1383,12 @@ end
                             class_w::AbstractDict{<:Any, <:Real},
                             average::MicroAvg, return_type)
     @warn W_PROMOTE_WARN
-    return _mc_helper(m, a, b, class_w, macro_avg, Vec)
+    return _mc_helper(m, a, b, class_w, macro_avg, Vector)
 end
 
 @inline function _mc_helper_b(m::CM, helper_name,
                               class_w::AbstractDict{<:Any, <:Real},
-                              average::NoAvg, return_type::Type{Vec})
+                              average::NoAvg, return_type::Type{Vector})
     level_w = _class_w(m.labels, class_w)
     return (1 .- helper_name(m, no_avg, return_type)) .* level_w
 end
@@ -1397,53 +1397,53 @@ end
                               class_w::AbstractDict{<:Any, <:Real},
                               average::NoAvg, return_type::Type{LittleDict})
     level_w = _class_w(m.labels, class_w)
-    return LittleDict(m.labels, ((1 .- helper_name(m, no_avg, Vec)) .* level_w))
+    return LittleDict(m.labels, ((1 .- helper_name(m, no_avg, Vector)) .* level_w))
 end
 
 @inline function _mc_helper_b(m::CM, helper_name,
                               class_w::AbstractDict{<:Any, <:Real},
                               average::MacroAvg, return_type)
-    return _mean(_mc_helper_b(m, helper_name, class_w, no_avg, Vec))
+    return _mean(_mc_helper_b(m, helper_name, class_w, no_avg, Vector))
 end
 
 @inline function _mc_helper_b(m::CM, helper_name,
                               class_w::AbstractDict{<:Any, <:Real},
                               average::MicroAvg, return_type)
     @warn W_PROMOTE_WARN
-    return _mc_helper_b(m, helper_name, class_w, macro_avg, Vec)
+    return _mc_helper_b(m, helper_name, class_w, macro_avg, Vector)
 end
 
 @inline function _mc_helper_b(m::CM, helper_name, average::NoAvg,
                               return_type::Type{LittleDict})
-    return LittleDict(m.labels, 1.0 .- helper_name(m, average, Vec))
+    return LittleDict(m.labels, 1.0 .- helper_name(m, average, Vector))
 end
 
 @inline function _mc_helper_b(m::CM, helper_name, average::NoAvg,
-                              return_type::Type{Vec})
-    return 1.0 .- helper_name(m, average, Vec)
+                              return_type::Type{Vector})
+    return 1.0 .- helper_name(m, average, Vector)
 end
 
 @inline function _mc_helper_b(m::CM, helper_name, average::MacroAvg,
                               return_type)
-    return 1.0 .- helper_name(m, average, Vec)
+    return 1.0 .- helper_name(m, average, Vector)
 end
 
 @inline function _mc_helper_b(m::CM, helper_name, average::MicroAvg,
                               return_type)
-    return 1.0 .- helper_name(m, average, Vec)
+    return 1.0 .- helper_name(m, average, Vector)
 end
 
 @inline function _mc_helper(m::CM, a::Vec{<:Real}, b::Vec{<:Real},
                             class_w::AbstractDict{<:Any, <:Real},
                             average::NoAvg, return_type::Type{LittleDict})
     level_w = _class_w(m.labels, class_w)
-    return LittleDict(m.labels, _mc_helper(m, a, b, class_w, no_avg, Vec))
+    return LittleDict(m.labels, _mc_helper(m, a, b, class_w, no_avg, Vector))
 end
 
 @inline function _mc_helper(m::CM, a::Vec{<:Real}, b::Vec{<:Real},
                             class_w::AbstractDict{<:Any, <:Real},
                             average::MacroAvg, return_type::Type{U}) where U
-    return _mean(_mc_helper(m, a, b, class_w, no_avg, Vec))
+    return _mean(_mc_helper(m, a, b, class_w, no_avg, Vector))
 end
 
 @inline function _mc_helper(m::CM, a::Vec{<:Real}, b::Vec{<:Real},
@@ -1557,14 +1557,14 @@ end
 end
 
 @inline function _fs_helper(m::CM, β::Real, rec::Vec{<:Real}, prec::Vec{<:Real},
-                    average::NoAvg, return_type::Type{Vec})
+                    average::NoAvg, return_type::Type{Vector})
     β2 = β^2
     return (1 + β2) .* (prec .* rec) ./ (β2 .* prec .+ rec)
 end
 
 @inline function _fs_helper(m::CM, β::Real, rec::Vec{<:Real}, prec::Vec{<:Real},
                     average::MacroAvg, return_type::Type{U}) where U
-    return _mean(_fs_helper(m, β, rec, prec, no_avg, Vec))
+    return _mean(_fs_helper(m, β, rec, prec, no_avg, Vector))
 end
 
 @inline function _fs_helper(m::CM, β::Real, rec::Real, prec::Real,
@@ -1575,12 +1575,12 @@ end
 
 function (f::MulticlassFScore)(m::CM)
     if f.average == micro_avg
-        rec = MulticlassRecall(; average=f.average, return_type=Vec)(m)
+        rec = MulticlassRecall(; average=f.average, return_type=Vector)(m)
         f.β == 1.0 && return rec
         return _fs_helper(m, f.β, rec, rec, f.average, f.return_type)
     end
-    rec = MulticlassRecall(; average=no_avg, return_type=Vec)(m)
-    prec = MulticlassPrecision(; average=no_avg, return_type=Vec)(m)
+    rec = MulticlassRecall(; average=no_avg, return_type=Vector)(m)
+    prec = MulticlassPrecision(; average=no_avg, return_type=Vector)(m)
     return _fs_helper(m, f.β, rec, prec, f.average, f.return_type)
 end
 
@@ -1590,20 +1590,20 @@ end
     return LittleDict(m.labels,
                       MulticlassFScore(β=β,
                                        average=no_avg,
-                                       return_type=Vec)(m) .* level_w)
+                                       return_type=Vector)(m) .* level_w)
 end
 
 @inline function _fs_helper(m::CM, w::AbstractDict{<:Any, <:Real}, β::Real,
-                    average::NoAvg, return_type::Type{Vec})
+                    average::NoAvg, return_type::Type{Vector})
     level_w = _class_w(m.labels, w)
     return MulticlassFScore(β=β,
                             average=no_avg,
-                            return_type=Vec)(m) .* level_w
+                            return_type=Vector)(m) .* level_w
 end
 
 @inline function _fs_helper(m::CM, w::AbstractDict{<:Any, <:Real}, β::Real,
                             average::MacroAvg, return_type::Type{U}) where U
-    return _mean(_fs_helper(m, w, β, no_avg, Vec))
+    return _mean(_fs_helper(m, w, β, no_avg, Vector))
 end
 
 @inline function _fs_helper(m::CM, w::AbstractDict{<:Any, <:Real}, β::Real,

--- a/src/measures/finite.jl
+++ b/src/measures/finite.jl
@@ -889,7 +889,7 @@ const DS_AVG_RET = "Options for `average` are: `no_avg`, `macro_avg` "*
     "applying in the `no_avg` case, are: `LittleDict` (default) or "*
     "`Vector`. "
 
-const DS_RET = "Options `return_type` are: "*
+const DS_RET = "Options for `return_type` are: "*
     "`LittleDict`(default) or "*
     "`Vector`. "
 
@@ -1084,6 +1084,10 @@ const W_KEY_MISMATCH = "Encountered target with levels different from the " *
 const W_PROMOTE_WARN = "Using macro averaging instead of micro averaging, as "*
     "class weights specified. "
 
+
+# ----------------------------------------------------
+# MulticlassTruePositive
+
 """
     MulticlassTruePositive(; return_type=LittleDict)
 
@@ -1097,9 +1101,14 @@ truth `y`, using default return type. $DS_RET
 For more information, run `info(MulticlassTruePositive)`.
 
 """
+function MulticlassTruePositive end
 const multiclass_true_positive  = MulticlassTruePositive()
 const multiclass_truepositive   = MulticlassTruePositive()
 const mtp = MulticlassTruePositive()
+
+
+# ----------------------------------------------------
+# MulticlassTrueNegative
 
 """
     MulticlassTrueNegative(; return_type=LittleDict)
@@ -1114,10 +1123,14 @@ Number of true negatives for multiclass observations `ŷ` and ground truth
 For more information, run `info(MulticlassTrueNegative)`.
 
 """
+function MulticlassTrueNegative end
 const multiclass_true_negative  = MulticlassTrueNegative()
 const multiclass_truenegative   = MulticlassTrueNegative()
 const mtn = MulticlassTrueNegative()
 
+
+# ----------------------------------------------------
+# MulticlassFalsePositive
 
 """
     MulticlassFalsePositive(; return_type=LittleDict)
@@ -1132,9 +1145,14 @@ truth `y`, using default return type. $DS_RET
 For more information, run `info(MulticlassFalsePositive)`.
 
 """
+function MulticlassPositive end
 const multiclass_false_positive = MulticlassFalsePositive()
 const multiclass_falsepositive  = MulticlassFalsePositive()
 const mfp = MulticlassFalsePositive()
+
+
+# ----------------------------------------------------
+# MulticlassFalseNegative
 
 """
     MulticlassFalseNegative(; return_type=LittleDict)
@@ -1149,9 +1167,14 @@ truth `y`, using default return type. $DS_RET
 For more information, run `info(MulticlassFalseNegative)`.
 
 """
+function MulticlassNegative end
 const multiclass_false_negative = MulticlassFalseNegative()
 const multiclass_falsenegative  = MulticlassFalseNegative()
 const mfn = MulticlassFalseNegative()
+
+
+# ----------------------------------------------------
+# MulticlassTruePositiveRate
 
 """
     MulticlassTruePositiveRate(; average=macro_avg, return_type=LittleDict)
@@ -1168,6 +1191,7 @@ averaging and return type. $DS_AVG_RET $CLASS_W
 For more information, run `info(MulticlassTruePositiveRate)`.
 
 """
+function MulticlassTruePositiveRate end
 const multiclass_true_positive_rate = MulticlassTruePositiveRate()
 const multiclass_truepositive_rate  = MulticlassTruePositiveRate()
 const multiclass_tpr                = MulticlassTruePositiveRate()
@@ -1176,6 +1200,10 @@ const multiclass_hit_rate           = MulticlassTruePositiveRate()
 const MTPR                          = MulticlassTruePositiveRate
 const multiclass_recall             = MulticlassTruePositiveRate()
 const MulticlassRecall              = MulticlassTruePositiveRate
+
+
+# ----------------------------------------------------
+# MulticlassTrueNegativeRate
 
 """
     MulticlassTrueNegativeRate(; average=macro_avg, return_type=LittleDict)
@@ -1191,6 +1219,7 @@ True negative rate for multiclass observations `ŷ` and ground truth
 For more information, run `info(MulticlassTrueNegativeRate)`.
 
 """
+function MulticlassTrueNegativeRate end
 const multiclass_true_negative_rate = MulticlassTrueNegativeRate()
 const multiclass_truenegative_rate  = MulticlassTrueNegativeRate()
 const multiclass_tnr                = MulticlassTrueNegativeRate()
@@ -1198,6 +1227,10 @@ const multiclass_specificity        = MulticlassTrueNegativeRate()
 const multiclass_selectivity        = MulticlassTrueNegativeRate()
 const MulticlassSpecificity         = MulticlassTrueNegativeRate
 const MTNR                          = MulticlassTrueNegativeRate
+
+
+# ----------------------------------------------------
+# MulticlassFalsePositiveRate
 
 """
     MulticlassFalsePositiveRate(; average=macro_avg, return_type=LittleDict)
@@ -1213,11 +1246,16 @@ False positive rate for multiclass observations `ŷ` and ground truth
 For more information, run `info(MulticlassFalsePositiveRate)`.
 
 """
+function MulticlassFalsePositiveRate end
 const multiclass_false_positive_rate = MulticlassFalsePositiveRate()
 const multiclass_falsepositive_rate  = MulticlassFalsePositiveRate()
 const multiclass_fpr                 = MulticlassFalsePositiveRate()
 const MFPR                           = MulticlassFalsePositiveRate
 const multiclass_fallout             = MFPR()
+
+
+# ----------------------------------------------------
+# MulticlassFalseNegativeRate
 
 """
     MulticlassFalseNegativeRate(; average=macro_avg, return_type=LittleDict)
@@ -1233,11 +1271,16 @@ False negative rate for multiclass observations `ŷ` and ground truth
 For more information, run `info(MulticlassFalseNegativeRate)`.
 
 """
+function MulticlassFalseNegativeRate end
 const multiclass_false_negative_rate = MulticlassFalseNegativeRate()
 const multiclass_falsenegative_rate  = MulticlassFalseNegativeRate()
 const multiclass_fnr                 = MulticlassFalseNegativeRate()
 const MFNR                           = MulticlassFalseNegativeRate
 const multiclass_miss_rate           = MFNR()
+
+
+# ----------------------------------------------------
+# MulticlassFalseDiscoveryRate
 
 """
     MulticlassFalseDiscoveryRate(; average=macro_avg, return_type=LittleDict)
@@ -1253,10 +1296,15 @@ False discovery rate for multiclass observations `ŷ` and ground truth
 For more information, run `info(MulticlassFalseDiscoveryRate)`.
 
 """
+function MulticlassFalseDiscoveryRate end
 const multiclass_false_discovery_rate = MulticlassFalseDiscoveryRate()
 const multiclass_falsediscovery_rate  = MulticlassFalseDiscoveryRate()
 const multiclass_fdr                  = MulticlassFalseDiscoveryRate()
 const MFDR                            = MulticlassFalseDiscoveryRate
+
+
+# ----------------------------------------------------
+# MulticlassPrecision
 
 """
     MulticlassPrecision(; average=macro_avg, return_type=LittleDict)
@@ -1272,11 +1320,16 @@ default averaging and return type. $DS_AVG_RET $CLASS_W
 For more information, run `info(MulticlassPrecision)`.
 
 """
+function MulticlassPrecision end
 const multiclass_precision                 = MulticlassPrecision()
 const multiclass_ppv                       = MulticlassPrecision()
 const multiclass_positive_predictive_value = MulticlassPrecision()
 const multiclass_positivepredictive_value  = MulticlassPrecision()
 const MPPV                                 = MulticlassPrecision
+
+
+# ----------------------------------------------------
+# MulticlassNPV
 
 """
     MulticlassNPV(; average=macro_avg, return_type=LittleDict)
@@ -1292,12 +1345,14 @@ Negative predictive value for multiclass observations `ŷ` and ground truth
 For more information, run `info(MulticlassNPV)`.
 
 """
+function MulticlassNPV end
 const multiclass_npv                       = MulticlassNPV()
 const multiclass_negative_predictive_value = MulticlassNPV()
 const multiclass_negativepredictive_value  = MulticlassNPV()
 const MNPV                                 = MulticlassNPV
 
 
+# -----------------------------------------------------
 ## INTERNAL FUCNTIONS ON MULTICLASS CONFUSION MATRIX
 
 _mtp(m::CM, return_type::Type{Vector}) = diag(m.mat)

--- a/src/measures/finite.jl
+++ b/src/measures/finite.jl
@@ -894,8 +894,8 @@ const DS_RET = "Options for `return_type` are: "*
     "`Vector`. "
 
 const CLASS_W = "An optional `AbstractDict`, denoted `class_w` above, "*
-    "keyed on `levels(y)`, specifies class weights. It applies only if "*
-    "`average=macro_avg`."
+    "keyed on `levels(y)`, specifies class weights. It applies if "*
+    "`average=macro_avg` or `average=no_avg`."
 
 """
     MulticlassFScore(; β=1.0, average=macro_avg, return_type=LittleDict)
@@ -907,7 +907,7 @@ multiclass observations.
     MulticlassFScore()(ŷ, y, class_w)
 
 Evaluate the default score on multiclass observations, `ŷ`, given
-ground truth values, `y`. $DS_AVG_RET (default). $CLASS_W
+ground truth values, `y`. $DS_AVG_RET $CLASS_W
 
 For more information, run `info(MulticlassFScore)`.
 
@@ -933,12 +933,12 @@ metadata_measure(MulticlassFScore;
 MLJModelInterface.docstring(::Type{<:MulticlassFScore}) =
     "Multiclass F_β score; aliases: " *
     "`macro_f1score=MulticlassFScore()`, "*
-    "`multiclass_f1score=MulticlassFScore(average=no_avg)` " *
+    "`multiclass_f1score=MulticlassFScore()` " *
     "`micro_f1score=MulticlassFScore(average=micro_avg)`."
 
 const micro_f1score      = MulticlassFScore(average=micro_avg)
 const macro_f1score      = MulticlassFScore(average=macro_avg)
-const multiclass_f1score = MulticlassFScore(average=no_avg)
+const multiclass_f1score = MulticlassFScore(average=macro_avg)
 
 for M in (:MulticlassTruePositive, :MulticlassTrueNegative,
           :MulticlassFalsePositive, :MulticlassFalseNegative)
@@ -1411,13 +1411,13 @@ end
 end
 
 @inline function _mc_helper(m::CM, a::Vec{<:Real}, b::Vec{<:Real},
-                            average::MacroAvg, return_type::Type{U}) where U
+                            average::MacroAvg, return_type)
     return _mean(_mc_helper(m, a, b, no_avg, Vector))
 end
 
 @inline function _mc_helper(m::CM, a::Vec{<:Real}, b::Vec{<:Real},
-                            average::MicroAvg, return_type::Type{U}) where U
-     a_sum, b_sum = sum(a), sum(b)
+                            average::MicroAvg, return_type) 
+    a_sum, b_sum = sum(a), sum(b)
     return a_sum / (a_sum + b_sum)
 end
 
@@ -1625,7 +1625,7 @@ end
 @inline function _fs_helper(m::CM, β::Real, rec::Real, prec::Real,
                             average::MicroAvg, return_type::Type{U}) where U
     β2 = β^2
-    return (1 + β2) * (prec * rec) / (β * prec + rec)
+    return (1 + β2) * (prec * rec) / (β2 * prec + rec)
 end
 
 function (f::MulticlassFScore)(m::CM)

--- a/src/measures/finite.jl
+++ b/src/measures/finite.jl
@@ -959,7 +959,7 @@ const _mtn_vec = MulticlassTrueNegative(return_type=Vector)
 
 for M in (:MulticlassTruePositiveRate, :MulticlassTrueNegativeRate,
           :MulticlassFalsePositiveRate, :MulticlassFalseNegativeRate,
-          :MulticlassFalseDiscoveryRate, :MulticlassPrecision, :MulticlassNPV)
+          :MulticlassFalseDiscoveryRate, :MulticlassPrecision, :MulticlassNegativePredictiveValue)
     ex = quote
         struct $M{T<:MulticlassAvg, U<:Union{Vector, LittleDict}} <: Measure
             average::T
@@ -1005,7 +1005,7 @@ metadata_measure.((MulticlassTruePositive, MulticlassTrueNegative);
     supports_weights         = false,
     supports_class_weights   = false)
 
-metadata_measure.((MulticlassTrueNegativeRate, MulticlassNPV);
+metadata_measure.((MulticlassTrueNegativeRate, MulticlassNegativePredictiveValue);
     target_scitype           = Vec{<:Finite{N}} where N,
     prediction_type          = :deterministic,
     orientation              = :score,
@@ -1067,8 +1067,8 @@ MMI.docstring(::Type{<:MulticlassFalseDiscoveryRate}) =
     "multiclass false discovery rate; "*
     "aliases: `multiclass_false_discovery_rate`, " *
     "`multiclass_falsediscovery_rate`, `multiclass_fdr`."
-# MMI.name(::Type{<:MulticlassNPV}) = "multiclass_negative_predictive_value"
-MMI.docstring(::Type{<:MulticlassNPV}) =
+# MMI.name(::Type{<:MulticlassNegativePredictiveValue}) = "multiclass_negative_predictive_value"
+MMI.docstring(::Type{<:MulticlassNegativePredictiveValue}) =
     "multiclass negative predictive value; aliases: " *
     "`multiclass_negative_predictive_value`, " *
     "`multiclass_negativepredictive_value`, `multiclass_npv`."
@@ -1329,27 +1329,27 @@ const MPPV                                 = MulticlassPrecision
 
 
 # ----------------------------------------------------
-# MulticlassNPV
+# MulticlassNegativePredictiveValue
 
 """
-    MulticlassNPV(; average=macro_avg, return_type=LittleDict)
+    MulticlassNegativePredictiveValue(; average=macro_avg, return_type=LittleDict)
 
-$(docstring(MulticlassNPV()))
+$(docstring(MulticlassNegativePredictiveValue()))
 
-    MulticlassNPV()(ŷ, y)
-    MulticlassNPV()(ŷ, y, class_w)
+    MulticlassNegativePredictiveValue()(ŷ, y)
+    MulticlassNegativePredictiveValue()(ŷ, y, class_w)
 
 Negative predictive value for multiclass observations `ŷ` and ground truth
 `y`, using default averaging and return type. $DS_AVG_RET $CLASS_W
 
-For more information, run `info(MulticlassNPV)`.
+For more information, run `info(MulticlassNegativePredictiveValue)`.
 
 """
-function MulticlassNPV end
-const multiclass_npv                       = MulticlassNPV()
-const multiclass_negative_predictive_value = MulticlassNPV()
-const multiclass_negativepredictive_value  = MulticlassNPV()
-const MNPV                                 = MulticlassNPV
+function MulticlassNegativePredictiveValue end
+const multiclass_npv                       = MulticlassNegativePredictiveValue()
+const multiclass_negative_predictive_value = MulticlassNegativePredictiveValue()
+const multiclass_negativepredictive_value  = MulticlassNegativePredictiveValue()
+const MNPV                                 = MulticlassNegativePredictiveValue
 
 
 # -----------------------------------------------------

--- a/src/measures/measures.jl
+++ b/src/measures/measures.jl
@@ -103,6 +103,7 @@ is_measure_type(::Type{<:Measure}) = true
 is_measure(m) = is_measure_type(typeof(m))
 
 
+
 ## DISPLAY AND INFO
 
 # Base.show(stream::IO, ::MIME"text/plain", m::Measure) =

--- a/test/measures/finite.jl
+++ b/test/measures/finite.jl
@@ -181,45 +181,99 @@ end
     class_w = Dict(0=>0,2=>2,1=>1)
     cm = confmat(ŷ, y, warn=false)
 
-    @test collect(values(multiclass_precision(cm))) ≈
-        collect(values(multiclass_precision(ŷ, y))) ≈ [0.4; 0.5; 2/3]
-    @test collect(keys(multiclass_precision(cm))) ==
-        collect(keys(multiclass_precision(ŷ, y))) == ["0"; "1"; "2"]
-    @test collect(values(multiclass_recall(cm))) ≈
-        collect(values(multiclass_recall(ŷ, y))) ≈ [0.5; 0.5; 0.5]
-    @test collect(values(macro_f1score(cm))) ≈
-        collect(values(macro_f1score(ŷ, y))) ≈ [4/9; 0.5; 4/7]
+    #               ┌─────────────────────────────────────────┐
+    #               │              Ground Truth               │
+    # ┌─────────────┼─────────────┬─────────────┬─────────────┤
+    # │  Predicted  │      0      │      1      │      2      │
+    # ├─────────────┼─────────────┼─────────────┼─────────────┤
+    # │      0      │      2      │      1      │      2      │
+    # ├─────────────┼─────────────┼─────────────┼─────────────┤
+    # │      1      │      2      │      2      │      0      │
+    # ├─────────────┼─────────────┼─────────────┼─────────────┤
+    # │      2      │      0      │      1      │      2      │
+    # └─────────────┴─────────────┴─────────────┴─────────────┘
 
-    @test collect(values(multiclass_precision(cm, class_w))) ≈
-        collect(values(multiclass_precision(ŷ, y, class_w))) ≈ [0.4; 0.5; 2/3] .* [0; 1; 2]
-    @test collect(values(multiclass_recall(cm, class_w))) ≈
-        collect(values(multiclass_recall(ŷ, y, class_w))) ≈ [0.5; 0.5; 0.5] .* [0; 1; 2]
-    @test collect(values(macro_f1score(cm, class_w))) ≈
-        collect(values(multiclass_f1score(ŷ, y, class_w))) ≈ [4/9; 0.5; 4/7] .* [0; 1; 2]
+    #`no_avg` and `LittleDict`
+    @test collect(values(MulticlassPrecision(average=no_avg)(cm))) ≈
+        collect(values(MulticlassPrecision(average=no_avg)(ŷ, y))) ≈
+        [0.4; 0.5; 2/3]
+    @test MulticlassPrecision(average=macro_avg)(cm) ≈
+        MulticlassPrecision(average=macro_avg)(ŷ, y) ≈ mean([0.4; 0.5; 2/3])
+    @test collect(keys(MulticlassPrecision(average=no_avg)(cm)))  ==
+        collect(keys(MulticlassPrecision(average=no_avg)(ŷ, y))) ==
+        ["0"; "1"; "2"]
+    @test collect(values(MulticlassRecall(average=no_avg)(cm))) ≈
+        collect(values(MulticlassRecall(average=no_avg)(ŷ, y))) ≈
+        [0.5; 0.5; 0.5]
+    @test collect(values(MulticlassFScore(average=no_avg)(cm))) ≈
+        collect(values(MulticlassFScore(average=no_avg)(ŷ, y))) ≈
+        [4/9; 0.5; 4/7]
 
+    #`no_avg` and `LittleDict` with class weights
+    @test collect(values(MulticlassPrecision(average=no_avg)(cm, class_w))) ≈
+        collect(values(MulticlassPrecision(average=no_avg)(ŷ, y, class_w))) ≈
+        [0.4; 0.5; 2/3] .* [0; 1; 2]
+    @test collect(values(MulticlassRecall(average=no_avg)(cm, class_w))) ≈
+        collect(values(MulticlassRecall(average=no_avg)(ŷ, y, class_w))) ≈
+        [0.5; 0.5; 0.5] .* [0; 1; 2]
+    @test collect(values(MulticlassFScore(average=no_avg)(cm, class_w))) ≈
+        collect(values(MulticlassFScore(average=no_avg)(ŷ, y, class_w))) ≈
+        [4/9; 0.5; 4/7] .* [0; 1; 2]
+
+    #`macro_avg` and `LittleDict`
+    macro_prec = MulticlassPrecision(average=macro_avg)
+    macro_rec  = MulticlassRecall(average=macro_avg)
+
+    @test macro_prec(cm)    ≈ macro_prec(ŷ, y)    ≈ mean([0.4, 0.5, 2/3])
+    @test macro_rec(cm)     ≈ macro_rec(ŷ, y)     ≈ mean([0.5; 0.5; 0.5])
+    @test macro_f1score(cm) ≈ macro_f1score(ŷ, y) ≈ mean([4/9; 0.5; 4/7])
+
+    #`micro_avg` and `LittleDict`
     micro_prec = MulticlassPrecision(average=micro_avg)
     micro_rec  = MulticlassRecall(average=micro_avg)
 
-    @test micro_prec(cm) == micro_prec(ŷ, y) == 0.5
-    @test micro_rec(cm) == micro_rec(ŷ, y) == 0.5
+    @test micro_prec(cm)    == micro_prec(ŷ, y)    == 0.5
+    @test micro_rec(cm)     == micro_rec(ŷ, y)     == 0.5
     @test micro_f1score(cm) == micro_f1score(ŷ, y) == 0.5
 
+    #`no_avg` and `AbstractVector` with class weights
     vec_precision = MulticlassPrecision(return_type=AbstractVector)
-    vec_recall  = MulticlassRecall(return_type=AbstractVector)
-    vec_f1score = MulticlassFScore(return_type=AbstractVector)
-    @test vec_precision(cm, class_w) ≈ vec_precision(ŷ, y, class_w) ≈
-                                [0.4; 0.5; 2/3] .* [0; 1; 2]
-    @test vec_recall(cm, class_w) ≈ vec_recall(ŷ, y, class_w) ≈
-                                [0.5; 0.5; 0.5] .* [0; 1; 2]
-    @test vec_f1score(cm, class_w) ≈ vec_f1score(ŷ, y, class_w) ≈
-                                [4/9; 0.5; 4/7] .* [0; 1; 2]
+    vec_recall    = MulticlassRecall(return_type=AbstractVector)
+    vec_f1score   = MulticlassFScore(return_type=AbstractVector)
 
+    @test vec_precision(cm, class_w) ≈ vec_precision(ŷ, y, class_w) ≈
+        mean([0.4; 0.5; 2/3] .* [0; 1; 2])
+    @test vec_recall(cm, class_w)    ≈ vec_recall(ŷ, y, class_w)    ≈
+        mean([0.5; 0.5; 0.5] .* [0; 1; 2])
+    @test vec_f1score(cm, class_w)   ≈ vec_f1score(ŷ, y, class_w)   ≈
+        mean([4/9; 0.5; 4/7] .* [0; 1; 2])
+
+    #`macro_avg` and `AbstractVector`
+    v_ma_prec = MulticlassPrecision(average=macro_avg,
+                                    return_type=AbstractVector)
+    v_ma_rec  = MulticlassRecall(average=macro_avg, return_type=AbstractVector)
+    v_ma_f1   = MulticlassFScore(average=macro_avg, return_type=AbstractVector)
+
+    @test v_ma_prec(cm) ≈ v_ma_prec(ŷ, y) ≈ mean([0.4, 0.5, 2/3])
+    @test v_ma_rec(cm)  ≈ v_ma_rec(ŷ, y)  ≈ mean([0.5; 0.5; 0.5])
+    @test v_ma_f1(cm)   ≈ v_ma_f1(ŷ, y)   ≈ mean([4/9; 0.5; 4/7])
+
+    #`macro_avg` and `AbstractVector` with class weights
+    @test v_ma_prec(cm, class_w) ≈ v_ma_prec(ŷ, y, class_w) ≈
+        mean([0.4, 0.5, 2/3] .* [0, 1, 2])
+    @test v_ma_rec(cm, class_w)  ≈ v_ma_rec(ŷ, y, class_w)  ≈
+        mean([0.5; 0.5; 0.5] .* [0, 1, 2])
+    @test v_ma_f1(cm, class_w)   ≈ v_ma_f1(ŷ, y, class_w)   ≈
+        mean([4/9; 0.5; 4/7] .* [0, 1, 2])
+
+    #`micro_avg` and `AbstractVector`
     v_mi_prec = MulticlassPrecision(average=micro_avg, return_type=AbstractVector)
     v_mi_rec  = MulticlassRecall(average=micro_avg, return_type=AbstractVector)
-    v_mi_f1  = MulticlassFScore(average=micro_avg, return_type=AbstractVector)
+    v_mi_f1   = MulticlassFScore(average=micro_avg, return_type=AbstractVector)
+
     @test v_mi_prec(cm) == v_mi_prec(ŷ, y) == 0.5
-    @test v_mi_rec(cm) == v_mi_rec(ŷ, y) == 0.5
-    @test v_mi_f1(cm) == v_mi_f1(ŷ, y) == 0.5
+    @test v_mi_rec(cm)  == v_mi_rec(ŷ, y)  == 0.5
+    @test v_mi_f1(cm)   == v_mi_f1(ŷ, y)   == 0.5
 end
 
 @testset "Metadata binary" begin
@@ -252,12 +306,16 @@ end
 
 @testset "Metadata multiclass" begin
     for m in (MulticlassRecall(), MulticlassPrecision(),
-              multiclass_f1score, multiclass_specificity)
+              MulticlassFScore(), MulticlassTrueNegativeRate())
         e = info(m)
-        m isa MulticlassRecall      && (@test e.name == "multiclass_true_positive_rate")
-        m isa MulticlassPrecision   && (@test e.name == "multiclass_positive_predictive_value")
-        m == multiclass_f1score     && (@test e.name == "MulticlassFScore{MLJBase.MacroAvg}")
-        m == multiclass_specificity && (@test e.name == "multiclass_true_negative_rate")
+        m isa MulticlassRecall &&
+            (@test e.name == "MulticlassTruePositiveRate")
+        m isa MulticlassPrecision   &&
+            (@test e.name == "MulticlassPrecision")
+        m isa MulticlassFScore &&
+            (@test e.name == "MulticlassFScore")
+        m isa MulticlassTrueNegativeRate &&
+            (@test e.name == "MulticlassTrueNegativeRate")
         @test e.target_scitype <: AbstractVector{<:Finite}
         @test e.prediction_type == :deterministic
         @test e.orientation == :score
@@ -359,20 +417,30 @@ end
     m = MulticlassFalseNegative()
     @test m(ŷ, y) == multiclass_falsenegative(ŷ, y)
     m = MulticlassTruePositiveRate()
-    @test m(ŷ, y) == multiclass_tpr(ŷ, y) == multiclass_truepositive_rate(ŷ, y)
-    @test m(ŷ, y, w) == multiclass_tpr(ŷ, y, w) == multiclass_truepositive_rate(ŷ, y, w)
+    @test m(ŷ, y) == multiclass_tpr(ŷ, y) ==
+        multiclass_truepositive_rate(ŷ, y)
+    @test m(ŷ, y, w) == multiclass_tpr(ŷ, y, w) ==
+        multiclass_truepositive_rate(ŷ, y, w)
     m = MulticlassTrueNegativeRate()
-    @test m(ŷ, y) == multiclass_tnr(ŷ, y) == multiclass_truenegative_rate(ŷ, y)
-    @test m(ŷ, y, w) == multiclass_tnr(ŷ, y, w) == multiclass_truenegative_rate(ŷ, y, w)
+    @test m(ŷ, y) == multiclass_tnr(ŷ, y) ==
+        multiclass_truenegative_rate(ŷ, y)
+    @test m(ŷ, y, w) == multiclass_tnr(ŷ, y, w) ==
+        multiclass_truenegative_rate(ŷ, y, w)
     m = MulticlassFalsePositiveRate()
-    @test m(ŷ, y) == multiclass_fpr(ŷ, y) == multiclass_falsepositive_rate(ŷ, y)
-    @test m(ŷ, y, w) == multiclass_fpr(ŷ, y, w) == multiclass_falsepositive_rate(ŷ, y, w)
+    @test m(ŷ, y) == multiclass_fpr(ŷ, y) ==
+        multiclass_falsepositive_rate(ŷ, y)
+    @test m(ŷ, y, w) == multiclass_fpr(ŷ, y, w) ==
+        multiclass_falsepositive_rate(ŷ, y, w)
     m = MulticlassFalseNegativeRate()
-    @test m(ŷ, y) == multiclass_fnr(ŷ, y) == multiclass_falsenegative_rate(ŷ, y)
-    @test m(ŷ, y, w) == multiclass_fnr(ŷ, y, w) == multiclass_falsenegative_rate(ŷ, y, w)
+    @test m(ŷ, y) == multiclass_fnr(ŷ, y) ==
+        multiclass_falsenegative_rate(ŷ, y)
+    @test m(ŷ, y, w) == multiclass_fnr(ŷ, y, w) ==
+        multiclass_falsenegative_rate(ŷ, y, w)
     m = MulticlassFalseDiscoveryRate()
-    @test m(ŷ, y) == multiclass_fdr(ŷ, y) == multiclass_falsediscovery_rate(ŷ, y)
-    @test m(ŷ, y, w) == multiclass_fdr(ŷ, y, w) == multiclass_falsediscovery_rate(ŷ, y, w)
+    @test m(ŷ, y) == multiclass_fdr(ŷ, y) ==
+        multiclass_falsediscovery_rate(ŷ, y)
+    @test m(ŷ, y, w) == multiclass_fdr(ŷ, y, w) ==
+        multiclass_falsediscovery_rate(ŷ, y, w)
     m = MulticlassPrecision()
     @test m(ŷ, y) == multiclass_precision(ŷ, y)
     @test m(ŷ, y, w) == multiclass_precision(ŷ, y, w)
@@ -380,37 +448,103 @@ end
     @test m(ŷ, y) == multiclass_npv(ŷ, y)
     @test m(ŷ, y, w) == multiclass_npv(ŷ, y, w)
     m = MulticlassFScore()
-    @test m(ŷ, y) == multiclass_f1score(ŷ, y)
-    @test m(ŷ, y, w) == multiclass_f1score(ŷ, y, w)
+    @test m(ŷ, y) == macro_f1score(ŷ, y)
+    @test m(ŷ, y, w) == macro_f1score(ŷ, y, w)
     # check synonyms
     m = MTPR(return_type=AbstractVector)
-    @test m(ŷ, y) == collect(values(multiclass_tpr(ŷ, y)))
-    @test m(ŷ, y, w) == collect(values(multiclass_tpr(ŷ, y, w)))
+    @test m(ŷ, y) == multiclass_tpr(ŷ, y)
+    @test m(ŷ, y, w) == multiclass_tpr(ŷ, y, w)
     m = MTNR(return_type=AbstractVector)
-    @test m(ŷ, y) == collect(values(multiclass_tnr(ŷ, y)))
-    @test m(ŷ, y, w) == collect(values(multiclass_tnr(ŷ, y, w)))
+    @test m(ŷ, y) == multiclass_tnr(ŷ, y)
+    @test m(ŷ, y, w) == multiclass_tnr(ŷ, y, w)
     m = MFPR()
     @test m(ŷ, y) == multiclass_fpr(ŷ, y) == multiclass_fallout(ŷ, y)
-    @test m(ŷ, y, w) == multiclass_fpr(ŷ, y, w) == multiclass_fallout(ŷ, y, w)
+    @test m(ŷ, y, w) == multiclass_fpr(ŷ, y, w) ==
+        multiclass_fallout(ŷ, y, w)
     m = MFNR()
-    @test m(ŷ, y) == multiclass_fnr(ŷ, y) == multiclass_miss_rate(ŷ, y)
-    @test m(ŷ, y, w) == multiclass_fnr(ŷ, y, w) == multiclass_miss_rate(ŷ, y, w)
+    @test m(ŷ, y) == multiclass_fnr(ŷ, y) ==
+        multiclass_miss_rate(ŷ, y)
+    @test m(ŷ, y, w) == multiclass_fnr(ŷ, y, w) ==
+        multiclass_miss_rate(ŷ, y, w)
     m = MFDR()
     @test m(ŷ, y) == multiclass_fdr(ŷ, y)
     @test m(ŷ, y, w) == multiclass_fdr(ŷ, y, w)
     m = MPPV()
-    @test m(ŷ, y) == multiclass_precision(ŷ, y) == multiclass_ppv(ŷ, y)
-    @test m(ŷ, y, w) == multiclass_precision(ŷ, y, w) == multiclass_ppv(ŷ, y, w)
+    @test m(ŷ, y) == MulticlassPrecision()(ŷ, y) ==
+        multiclass_ppv(ŷ, y)
+    @test m(ŷ, y, w) == MulticlassPrecision()(ŷ, y, w) ==
+        multiclass_ppv(ŷ, y, w)
     m = MulticlassRecall()
-    @test m(ŷ, y) == multiclass_tpr(ŷ, y) == multiclass_recall(ŷ, y)
-    @test m(ŷ, y, w) == multiclass_tpr(ŷ, y, w) == multiclass_recall(ŷ, y, w)
-    @test m(ŷ, y) == multiclass_sensitivity(ŷ, y) == multiclass_hit_rate(ŷ, y)
-    @test m(ŷ, y, w) == multiclass_sensitivity(ŷ, y, w) == multiclass_hit_rate(ŷ, y, w)
+    @test m(ŷ, y) == multiclass_tpr(ŷ, y)
+    @test m(ŷ, y, w) == multiclass_tpr(ŷ, y, w)
+    @test m(ŷ, y) == multiclass_sensitivity(ŷ, y) ==
+        multiclass_hit_rate(ŷ, y)
+    @test m(ŷ, y, w) == multiclass_sensitivity(ŷ, y, w) ==
+        multiclass_hit_rate(ŷ, y, w)
     m = MulticlassSpecificity()
     @test m(ŷ, y) == multiclass_tnr(ŷ, y) == multiclass_specificity(ŷ, y) ==
-                                             multiclass_selectivity(ŷ, y)
-    @test m(ŷ, y, w) == multiclass_tnr(ŷ, y, w) == multiclass_specificity(ŷ, y, w) ==
-                                             multiclass_selectivity(ŷ, y, w)
+        multiclass_selectivity(ŷ, y)
+    @test m(ŷ, y, w) == multiclass_tnr(ŷ, y, w) ==
+        multiclass_specificity(ŷ, y, w) == multiclass_selectivity(ŷ, y, w)
+end
+
+
+@testset "Additional multiclass functions" begin
+    table = reshape(collect("aabbbccccddbabccbacccd"), 11, 2)
+    table = coerce(table, Multiclass);
+    yhat = table[:,1] # ['a', 'a', 'b', 'b', 'b', 'c', 'c', 'c', 'c', 'd', 'd']
+    y    = table[:,2] # ['b', 'a', 'b', 'c', 'c', 'b', 'a', 'c', 'c', 'c', 'd']
+    class_w = Dict('a'=>7, 'b'=>5, 'c'=>2, 'd'=> 0)
+
+    # class | TP | FP | TP + FP | precision | FN | TP + FN | recall
+    # ------|----|----|------------------------------------|-------
+    # a     | 1  | 1  | 2       | 1/2       | 1  | 2       | 1/2
+    # b     | 1  | 2  | 3       | 1/3       | 2  | 3       | 1/3
+    # c     | 2  | 2  | 4       | 1/2       | 3  | 5       | 2/5
+    # d     | 1  | 1  | 2       | 1/2       | 0  | 1       | 1
+
+    # helper:
+    inverse(x) = 1/x
+    harmonic_mean(x...) = inverse(mean(inverse.(x)))
+
+    # precision:
+    p_macro = mean([1/2, 1/3, 1/2, 1/2])
+    @test MulticlassPrecision()(yhat, y) ≈ p_macro
+    p_macro_w = mean([7/2, 5/3, 2/2, 0/2])
+    @test MulticlassPrecision()(yhat, y, class_w) ≈ p_macro_w
+    @test p_macro_w ≈
+        @test_logs((:warn, r"Using macro"),
+                     MulticlassPrecision(average=micro_avg)(yhat, y, class_w))
+    p_micro = (1 + 1 + 2 + 1)/(2 + 3 + 4 + 2)
+    @test MulticlassPrecision(average=micro_avg)(yhat, y) ≈ p_micro
+
+    # recall:
+    r_macro = mean([1/2, 1/3, 2/5, 1])
+    @test MulticlassRecall(average=macro_avg)(yhat, y) ≈ r_macro
+    r_macro_w = mean([7/2, 5/3, 4/5, 0/1])
+    @test MulticlassRecall(average=macro_avg)(yhat, y, class_w) ≈ r_macro_w
+    @test r_macro_w ≈
+        @test_logs((:warn, r"Using macro"),
+                     MulticlassRecall(average=micro_avg)(yhat, y, class_w))
+    r_micro = (1 + 1 + 2 + 1)/(2 + 3 + 5 + 1)
+    @test MulticlassPrecision(average=micro_avg)(yhat, y) ≈ r_micro
+
+    # fscore:
+    harm_means = [harmonic_mean(1/2, 1/2),
+                     harmonic_mean(1/3, 1/3),
+                     harmonic_mean(1/2, 2/5),
+                     harmonic_mean(1/2, 1)]
+    f1_macro = mean(harm_means)
+    @test MulticlassFScore(average=macro_avg)(yhat, y) ≈ f1_macro
+    @test MulticlassFScore(average=no_avg, return_type=Vec)(yhat, y, class_w) ≈
+        [7, 5, 2, 0] .* harm_means
+    f1_macro_w = mean([7, 5, 2, 0] .* harm_means)
+    @test MulticlassFScore(average=macro_avg)(yhat, y, class_w) ≈ f1_macro_w
+    @test f1_macro_w ≈
+        @test_logs((:warn, r"Using macro"),
+                     MulticlassFScore(average=micro_avg)(yhat, y, class_w))
+    f1_micro = harmonic_mean(p_micro, r_micro)
+    @test MulticlassFScore(average=micro_avg)(yhat, y) ≈ f1_micro
 end
 
 @testset "ROC" begin

--- a/test/measures/finite.jl
+++ b/test/measures/finite.jl
@@ -1,5 +1,7 @@
 rng = StableRNG(51803)
 
+const Vec = AbstractVector
+
 @testset "built-in classifier measures" begin
     y    = categorical(collect("asdfasdfaaassdd"))
     yhat = categorical(collect("asdfaadfaasssdf"))

--- a/test/measures/finite.jl
+++ b/test/measures/finite.jl
@@ -446,7 +446,7 @@ end
     m = MulticlassPrecision()
     @test m(ŷ, y) == multiclass_precision(ŷ, y)
     @test m(ŷ, y, w) == multiclass_precision(ŷ, y, w)
-    m = MulticlassNPV()
+    m = MulticlassNegativePredictiveValue()
     @test m(ŷ, y) == multiclass_npv(ŷ, y)
     @test m(ŷ, y, w) == multiclass_npv(ŷ, y, w)
     m = MulticlassFScore()

--- a/test/measures/finite.jl
+++ b/test/measures/finite.jl
@@ -238,10 +238,10 @@ end
     @test micro_rec(cm)     == micro_rec(ŷ, y)     == 0.5
     @test micro_f1score(cm) == micro_f1score(ŷ, y) == 0.5
 
-    #`no_avg` and `AbstractVector` with class weights
-    vec_precision = MulticlassPrecision(return_type=AbstractVector)
-    vec_recall    = MulticlassRecall(return_type=AbstractVector)
-    vec_f1score   = MulticlassFScore(return_type=AbstractVector)
+    #`no_avg` and `Vector` with class weights
+    vec_precision = MulticlassPrecision(return_type=Vector)
+    vec_recall    = MulticlassRecall(return_type=Vector)
+    vec_f1score   = MulticlassFScore(return_type=Vector)
 
     @test vec_precision(cm, class_w) ≈ vec_precision(ŷ, y, class_w) ≈
         mean([0.4; 0.5; 2/3] .* [0; 1; 2])
@@ -250,17 +250,17 @@ end
     @test vec_f1score(cm, class_w)   ≈ vec_f1score(ŷ, y, class_w)   ≈
         mean([4/9; 0.5; 4/7] .* [0; 1; 2])
 
-    #`macro_avg` and `AbstractVector`
+    #`macro_avg` and `Vector`
     v_ma_prec = MulticlassPrecision(average=macro_avg,
-                                    return_type=AbstractVector)
-    v_ma_rec  = MulticlassRecall(average=macro_avg, return_type=AbstractVector)
-    v_ma_f1   = MulticlassFScore(average=macro_avg, return_type=AbstractVector)
+                                    return_type=Vector)
+    v_ma_rec  = MulticlassRecall(average=macro_avg, return_type=Vector)
+    v_ma_f1   = MulticlassFScore(average=macro_avg, return_type=Vector)
 
     @test v_ma_prec(cm) ≈ v_ma_prec(ŷ, y) ≈ mean([0.4, 0.5, 2/3])
     @test v_ma_rec(cm)  ≈ v_ma_rec(ŷ, y)  ≈ mean([0.5; 0.5; 0.5])
     @test v_ma_f1(cm)   ≈ v_ma_f1(ŷ, y)   ≈ mean([4/9; 0.5; 4/7])
 
-    #`macro_avg` and `AbstractVector` with class weights
+    #`macro_avg` and `Vector` with class weights
     @test v_ma_prec(cm, class_w) ≈ v_ma_prec(ŷ, y, class_w) ≈
         mean([0.4, 0.5, 2/3] .* [0, 1, 2])
     @test v_ma_rec(cm, class_w)  ≈ v_ma_rec(ŷ, y, class_w)  ≈
@@ -268,10 +268,10 @@ end
     @test v_ma_f1(cm, class_w)   ≈ v_ma_f1(ŷ, y, class_w)   ≈
         mean([4/9; 0.5; 4/7] .* [0, 1, 2])
 
-    #`micro_avg` and `AbstractVector`
-    v_mi_prec = MulticlassPrecision(average=micro_avg, return_type=AbstractVector)
-    v_mi_rec  = MulticlassRecall(average=micro_avg, return_type=AbstractVector)
-    v_mi_f1   = MulticlassFScore(average=micro_avg, return_type=AbstractVector)
+    #`micro_avg` and `Vector`
+    v_mi_prec = MulticlassPrecision(average=micro_avg, return_type=Vector)
+    v_mi_rec  = MulticlassRecall(average=micro_avg, return_type=Vector)
+    v_mi_f1   = MulticlassFScore(average=micro_avg, return_type=Vector)
 
     @test v_mi_prec(cm) == v_mi_prec(ŷ, y) == 0.5
     @test v_mi_rec(cm)  == v_mi_rec(ŷ, y)  == 0.5
@@ -453,10 +453,10 @@ end
     @test m(ŷ, y) == macro_f1score(ŷ, y)
     @test m(ŷ, y, w) == macro_f1score(ŷ, y, w)
     # check synonyms
-    m = MTPR(return_type=AbstractVector)
+    m = MTPR(return_type=Vector)
     @test m(ŷ, y) == multiclass_tpr(ŷ, y)
     @test m(ŷ, y, w) == multiclass_tpr(ŷ, y, w)
-    m = MTNR(return_type=AbstractVector)
+    m = MTNR(return_type=Vector)
     @test m(ŷ, y) == multiclass_tnr(ŷ, y)
     @test m(ŷ, y, w) == multiclass_tnr(ŷ, y, w)
     m = MFPR()
@@ -538,7 +538,7 @@ end
                      harmonic_mean(1/2, 1)]
     f1_macro = mean(harm_means)
     @test MulticlassFScore(average=macro_avg)(yhat, y) ≈ f1_macro
-    @test MulticlassFScore(average=no_avg, return_type=Vec)(yhat, y, class_w) ≈
+    @test MulticlassFScore(average=no_avg, return_type=Vector)(yhat, y, class_w) ≈
         [7, 5, 2, 0] .* harm_means
     f1_macro_w = mean([7, 5, 2, 0] .* harm_means)
     @test MulticlassFScore(average=macro_avg)(yhat, y, class_w) ≈ f1_macro_w


### PR DESCRIPTION
Resolves the merge conflicts in #455. 

Other changes:

- Change default averaging to `macro_avg` (from `no_avg`)
- Rename `MulticlassNPV` to `MulticlassNegativePredictiveValue`
- Change `AbstractVector` option for `return_type` to `Vector` 
- In anticipation of #450, name the measures and anchor their document strings using types rather than an instances
- Further corrections and clean ups to doc-strings
- Fix some tests and add some tests

For the release notes:

---

Add the multiclass classification measures (applying to any `Finite` target):

-  `MulticlassFalseNegative`, `MulticlassFalsePositive`,  `MulticlassTrueNegative`, `MulticlassTruePositive`. When instances are called, as in `MulticlassFalseNegative()(yhat, y)`, then they return a dictionary keyed on class, or a vector , according to the keyword argument `return_type=...` provided the constructor; options: `LittleDict` (default), `Vector` (#456 @ven-k)

- `MulticlassFalseDiscoveryRate`, `MulticlassFalseNegativeRate`, `MulticlassNegativePredictiveValue`, `MulticlassPrecision`, `MulticlassTrueNegativeRate`, `MulticlassTruePositiveRate`. Averaging method specified by keyword `average=...`, with options `micro_avg`, `macro_avg` and `no_avg`. A float is returned unless `average=no_avg`, in which case the keyword argument `return_type` determines the return type, as above. Instances can be provided a dictionary of class weights, `class_w`, as in `MulticlassPrecision()(yhat, y, class_w)` (#456 @ven-k)

- `MulticlassFScore`, with averaging and return type options specified as above. Instances can be similarly called with class weights (#456 @ven-k)

The averaging options closely mimic those implemented in [scikit-learn](https://scikit-learn.org/stable/modules/generated/sklearn.metrics.f1_score.html), except that the binary versions have a separate implementation in MLJ (`TruePositiveRate`, `FScore`, etc). Note that the multiclass versions are "symmetrized" versions of the binary ones - so they apply to any `Finite` target, while the original binary measures apply only to `OrderedFactor{2}`. In particular, `FScore()` (for example) on `OrderedFactor{2}` is different from `MulticlassFScore()` on `OrderedFactor{2}`.
