### PR TITLE
Cleanup the measures (aka loss functions and scores)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ repository provides core functionality for MLJ, including:
   for **performance measures** (losses and scores), enabling the
   integration of the
   [LossFunctions.jl](https://github.com/JuliaML/LossFunctions.jl)
-  library, user-defined measures, as well as about two dozen natively
+  library, user-defined measures, as well as about forty natively
   defined measures.
 
 - integration with [OpenML](https://www.openml.org)

--- a/src/MLJBase.jl
+++ b/src/MLJBase.jl
@@ -210,32 +210,34 @@ export cross_entropy, BrierScore, brier_score,
     BrierLoss, brier_loss,
     LogLoss, log_loss,
     misclassification_rate, mcr, accuracy,
-    balanced_accuracy, bacc, bac,
+    balanced_accuracy, bacc, bac, BalancedAccuracy,
     matthews_correlation, mcc, MCC, AUC, AreaUnderCurve,
-    MisclassificationRate, Accuracy, MCR, BACC, BAC
+    MisclassificationRate, Accuracy, MCR, BACC, BAC,
+    MatthewsCorrelation
 
 # measures/finite.jl -- Multiclass{2} (order independent):
 export auc, area_under_curve, roc_curve, roc
 
 # measures/finite.jl -- OrderedFactor{2} (order dependent):
 export TruePositive, TrueNegative, FalsePositive, FalseNegative,
-       TruePositiveRate, TrueNegativeRate, FalsePositiveRate,
-       FalseNegativeRate, FalseDiscoveryRate, Precision, NPV, FScore,
-       # standard synonyms
-       TPR, TNR, FPR, FNR, FDR, PPV,
-       Recall, Specificity, BACC,
-       # instances and their synonyms
-       truepositive, truenegative, falsepositive, falsenegative,
-       true_positive, true_negative, false_positive, false_negative,
-       truepositive_rate, truenegative_rate, falsepositive_rate,
-       true_positive_rate, true_negative_rate, false_positive_rate,
-       falsenegative_rate, negativepredictive_value,
-       false_negative_rate, negative_predictive_value,
-       positivepredictive_value, positive_predictive_value,
-       tpr, tnr, fpr, fnr,
-       falsediscovery_rate, false_discovery_rate, fdr, npv, ppv,
-       recall, sensitivity, hit_rate, miss_rate,
-       specificity, selectivity, f1score, fallout
+    TruePositiveRate, TrueNegativeRate, FalsePositiveRate,
+    FalseNegativeRate, FalseDiscoveryRate, Precision, NPV, FScore,
+    NegativePredictiveValue,
+    # standard synonyms
+    TPR, TNR, FPR, FNR, FDR, PPV,
+    Recall, Specificity, BACC,
+    # instances and their synonyms
+    truepositive, truenegative, falsepositive, falsenegative,
+    true_positive, true_negative, false_positive, false_negative,
+    truepositive_rate, truenegative_rate, falsepositive_rate,
+    true_positive_rate, true_negative_rate, false_positive_rate,
+    falsenegative_rate, negativepredictive_value,
+    false_negative_rate, negative_predictive_value,
+    positivepredictive_value, positive_predictive_value,
+    tpr, tnr, fpr, fnr,
+    falsediscovery_rate, false_discovery_rate, fdr, npv, ppv,
+    recall, sensitivity, hit_rate, miss_rate,
+    specificity, selectivity, f1score, fallout
 
 # measures/finite.jl -- Finite{N} - multiclass generalizations of
 # above OrderedFactor{2} measures (but order independent):

--- a/src/MLJBase.jl
+++ b/src/MLJBase.jl
@@ -203,7 +203,7 @@ export mav, mae, mape, rms, rmsl, rmslp1, rmsp, l1, l2, log_cosh,
     MAPE, MeanAbsoluteProportionalError, log_cosh_loss, LogCosh, LogCoshLoss
 
 # measures/confusion_matrix.jl:
-export confusion_matrix, confmat
+export confusion_matrix, confmat, ConfusionMatrix
 
 # measures/finite.jl:
 export cross_entropy, BrierScore, brier_score,

--- a/src/MLJBase.jl
+++ b/src/MLJBase.jl
@@ -52,6 +52,13 @@ const Dist = Distributions
 # from Standard Library:
 using Statistics, LinearAlgebra, Random, InteractiveUtils
 
+# external loss functions:
+import LossFunctions: DWDMarginLoss, ExpLoss, L1HingeLoss, L2HingeLoss,
+    L2MarginLoss, LogitMarginLoss, ModifiedHuberLoss, PerceptronLoss,
+    SigmoidLoss, SmoothedL1HingeLoss, ZeroOneLoss, HuberLoss, L1EpsilonInsLoss,
+    L2EpsilonInsLoss, LPDistLoss, LogitDistLoss, PeriodicLoss, QuantileLoss
+
+
 # ===================================================================
 ## EXPORTS
 
@@ -261,6 +268,21 @@ export MulticlassTruePositive, MulticlassTrueNegative, MulticlassFalsePositive,
       # averaging modes
       no_avg, macro_avg, micro_avg
 
+# measures/loss_functions_interface.jl
+export dwd_margin_loss, exp_loss, l1_hinge_loss, l2_hinge_loss, l2_margin_loss,
+    logit_margin_loss, modified_huber_loss, perceptron_loss, sigmoid_loss,
+    smoothed_l1_hinge_loss, zero_one_loss, huber_loss, l1_epsilon_ins_loss,
+    l2_epsilon_ins_loss, lp_dist_loss, logit_dist_loss, periodic_loss,
+    quantile_loss
+
+# ------------------------------------------------------------------------
+# re-export from LossFunctions:
+export DWDMarginLoss, ExpLoss, L1HingeLoss, L2HingeLoss, L2MarginLoss,
+    LogitMarginLoss, ModifiedHuberLoss, PerceptronLoss, SigmoidLoss,
+    SmoothedL1HingeLoss, ZeroOneLoss, HuberLoss, L1EpsilonInsLoss,
+    L2EpsilonInsLoss, LPDistLoss, LogitDistLoss, PeriodicLoss,
+    QuantileLoss
+ 
 # -------------------------------------------------------------------
 # re-export from Random, StatsBase, Statistics, Distributions,
 # OrderedCollections, CategoricalArrays, InvertedIndices:

--- a/src/MLJBase.jl
+++ b/src/MLJBase.jl
@@ -186,7 +186,13 @@ export orientation, reports_each_observation,
     spports_weights, prediction_type
 
 # measures/continuous.jl:
-export mav, mae, mape, rms, rmsl, rmslp1, rmsp, l1, l2, log_cosh
+export mav, mae, mape, rms, rmsl, rmslp1, rmsp, l1, l2, log_cosh,
+    MAV, MAE, MeanAbsoluteError, mean_absolute_error, mean_absolute_value,
+    LPLoss, RootMeanSquaredProportionalError, RMSP,
+    RMS, rmse, RootMeanSquaredError, root_mean_squared_error,
+    RootMeanSquaredLogError, RMSL, root_mean_squared_log_error, rmsl, rmsle,
+    RootMeanSquaredLogProportionalError, rmsl1, RMSLP,
+    MAPE, MeanAbsoluteProportionalError, log_cosh_loss, LogCosh, LogCoshLoss
 
 # measures/confusion_matrix.jl:
 export confusion_matrix, confmat

--- a/src/MLJBase.jl
+++ b/src/MLJBase.jl
@@ -80,29 +80,30 @@ export @mlj_model, metadata_pkg, metadata_model
 
 # model api
 export fit, update, update_data, transform, inverse_transform,
-       fitted_params, predict, predict_mode, predict_mean, predict_median, predict_joint,
-       evaluate, clean!
+    fitted_params, predict,
+    predict_mode, predict_mean, predict_median, predict_joint,
+    evaluate, clean!
 
 # model/measure matching:
 export Checker, matching
 
 # model traits
 export input_scitype, output_scitype, target_scitype,
-       is_pure_julia, package_name, package_license,
-       load_path, package_uuid, package_url,
-       is_wrapper, supports_weights, supports_online,
-       docstring, name, is_supervised,
-       prediction_type, implemented_methods, hyperparameters,
-       hyperparameter_types, hyperparameter_ranges
+    is_pure_julia, package_name, package_license,
+    load_path, package_uuid, package_url,
+    is_wrapper, supports_weights, supports_online,
+    docstring, name, is_supervised,
+    prediction_type, implemented_methods, hyperparameters,
+    hyperparameter_types, hyperparameter_ranges
 
 # data operations
 export matrix, int, classes, decoder, table,
-       nrows, selectrows, selectcols, select
+    nrows, selectrows, selectcols, select
 
 # re-exports from MLJScientificTypes
 export Unknown, Known, Finite, Infinite,
-       OrderedFactor, Multiclass, Count, Continuous, Textual,
-       Binary, ColorImage, GrayImage, Image, Table
+    OrderedFactor, Multiclass, Count, Continuous, Textual,
+    Binary, ColorImage, GrayImage, Image, Table
 export scitype, scitype_union, elscitype, nonmissing, trait
 export coerce, coerce!, autotype, schema, info
 
@@ -183,7 +184,7 @@ export measures, metadata_measure
 export orientation, reports_each_observation,
     is_feature_dependent, aggregation,
     aggregate, default_measure, value,
-    spports_weights, prediction_type
+    supports_class_weights, prediction_type, human_name
 
 # measures/continuous.jl:
 export mav, mae, mape, rms, rmsl, rmslp1, rmsp, l1, l2, log_cosh,
@@ -197,11 +198,14 @@ export mav, mae, mape, rms, rmsl, rmslp1, rmsp, l1, l2, log_cosh,
 # measures/confusion_matrix.jl:
 export confusion_matrix, confmat
 
-# measures/finite.jl
+# measures/finite.jl:
 export cross_entropy, BrierScore, brier_score,
-       misclassification_rate, mcr, accuracy,
-       balanced_accuracy, bacc, bac,
-       matthews_correlation, mcc
+    BrierLoss, brier_loss,
+    LogLoss, log_loss,
+    misclassification_rate, mcr, accuracy,
+    balanced_accuracy, bacc, bac,
+    matthews_correlation, mcc, MCC, AUC, AreaUnderCurve,
+    MisclassificationRate, Accuracy, MCR, BACC, BAC
 
 # measures/finite.jl -- Multiclass{2} (order independent):
 export auc, area_under_curve, roc_curve, roc

--- a/src/composition/models/pipelines.jl
+++ b/src/composition/models/pipelines.jl
@@ -100,7 +100,7 @@ function is_uppercase(char::Char)
     i > 64 && i < 91
 end
 
-function snakecase(str::AbstractString)
+function snakecase(str::AbstractString; delim='_')
     snake = Char[]
     n = length(str)
     for i in eachindex(str)
@@ -108,7 +108,7 @@ function snakecase(str::AbstractString)
         if is_uppercase(char)
             if i != 1 && i < n &&
                 !(is_uppercase(str[i + 1]) && is_uppercase(str[i - 1]))
-                push!(snake, '_')
+                push!(snake, delim)
             end
             push!(snake, lowercase(char))
         else

--- a/src/composition/models/pipelines.jl
+++ b/src/composition/models/pipelines.jl
@@ -118,6 +118,8 @@ function snakecase(str::AbstractString; delim='_')
     return join(snake)
 end
 
+snakecase(s::Symbol) = Symbol(snakecase(string(s)))
+
 # `M` is a model type and the return value a `Symbol`. The
 # `existing_names` gets updated.
 function generate_name!(M::DataType, existing_names)

--- a/src/measures/confusion_matrix.jl
+++ b/src/measures/confusion_matrix.jl
@@ -226,7 +226,7 @@ Use `ConfusionMatrix(perm=[2, 1])` to reverse the class order for binary
 data. For more than two classes, specify an appropriate permutation, as in
 `ConfusionMatrix(perm=[2, 3, 1])`.
 """,
-scientific_type=DOC_ORDERED_FACTOR_BINARY)
+scitype=DOC_ORDERED_FACTOR_BINARY)
 
 # calling behaviour:
 (m::ConfusionMatrix)(ŷ::Vec{<:CategoricalValue}, y::Vec{<:CategoricalValue}) =

--- a/src/measures/confusion_matrix.jl
+++ b/src/measures/confusion_matrix.jl
@@ -1,36 +1,41 @@
+## CONFUSION MATRIX OBJECT
+
 """
-    ConfusionMatrix{C}
+    ConfusionMatrixObject{C}
 
 Confusion matrix with `C ≥ 2` classes. Rows correspond to predicted values
 and columns to the ground truth.
 """
-struct ConfusionMatrix{C}
+struct ConfusionMatrixObject{C}
     mat::Matrix
     labels::Vector{String}
 end
 
 """
-    ConfusionMatrix(m, labels)
+    ConfusionMatrixObject(m, labels)
 
 Instantiates a confusion matrix out of a square integer matrix `m`.
 Rows are the predicted class, columns the ground truth. See also the
 [wikipedia article](https://en.wikipedia.org/wiki/Confusion_matrix).
 
 """
-function ConfusionMatrix(m::Matrix{Int}, labels::Vector{String})
+function ConfusionMatrixObject(m::Matrix{Int}, labels::Vector{String})
     s = size(m)
     s[1] == s[2] || throw(ArgumentError("Expected a square matrix."))
     s[1] > 1 || throw(ArgumentError("Expected a matrix of size ≥ 2x2."))
     length(labels) == s[1] ||
         throw(ArgumentError("As many labels as classes must be provided."))
-    ConfusionMatrix{s[1]}(m, labels)
+    ConfusionMatrixObject{s[1]}(m, labels)
 end
 
 # allow to access cm[i,j] but not set (it's immutable)
-Base.getindex(cm::ConfusionMatrix, inds...) = getindex(cm.mat, inds...)
+Base.getindex(cm::ConfusionMatrixObject, inds...) = getindex(cm.mat, inds...)
 
 """
-    confusion_matrix(ŷ, y; rev=false)
+    _confmat(ŷ, y; rev=false)
+
+A private method. General users should use `confmat` or other instance
+of the measure type [`ConfusionMatrix`](@ref).
 
 Computes the confusion matrix given a predicted `ŷ` with categorical elements
 and the actual `y`. Rows are the predicted class, columns the ground truth.
@@ -58,10 +63,10 @@ The `confusion_matrix` is a measure (although neither a score nor a
 loss) and so may be specified as such in calls to `evaluate`,
 `evaluate!`, although not in `TunedModel`s.  In this case, however,
 there no way to specify an ordering different from `levels(y)`, where
-`y` is the target. 
+`y` is the target.
 
 """
-function confusion_matrix(ŷ::Vec{<:CategoricalValue}, y::Vec{<:CategoricalValue};
+function _confmat(ŷ::Vec{<:CategoricalValue}, y::Vec{<:CategoricalValue};
                           rev::Union{Nothing,Bool}=nothing,
                           perm::Union{Nothing,Vector{<:Integer}}=nothing,
                           warn::Bool=true)
@@ -73,9 +78,15 @@ function confusion_matrix(ŷ::Vec{<:CategoricalValue}, y::Vec{<:CategoricalValu
         throw(ArgumentError("Keyword `rev` can only be used in binary case."))
     end
     if perm !== nothing && !isempty(perm)
-        length(perm) == nc || throw(ArgumentError("`perm` must be of length matching the number of classes."))
-        Set(perm) == Set(collect(1:nc)) || throw(ArgumentError("`perm` must specify a valid permutation of the classes."))
+        length(perm) == nc ||
+            throw(ArgumentError("`perm` must be of length matching the "*
+                                "number of classes."))
+        Set(perm) == Set(collect(1:nc)) ||
+            throw(ArgumentError("`perm` must specify a valid permutation of "*
+                                "`[1, 2, ..., c]`, where `c` is "*
+                                "number of classes."))
     end
+
     # warning
     if rev === nothing && perm === nothing
         if warn &&
@@ -91,7 +102,7 @@ function confusion_matrix(ŷ::Vec{<:CategoricalValue}, y::Vec{<:CategoricalValu
         end
         rev  = false
         perm = Int[]
-    elseif rev !== nothing
+    elseif rev !== nothing && nc == 2
         # rev takes precedence in binary case
         if rev
             perm = [2, 1]
@@ -106,7 +117,7 @@ function confusion_matrix(ŷ::Vec{<:CategoricalValue}, y::Vec{<:CategoricalValu
         @inbounds for i in eachindex(y)
             cmat[int(ŷ[i]), int(y[i])] += 1
         end
-        return ConfusionMatrix(cmat, string.(levels_))
+        return ConfusionMatrixObject(cmat, string.(levels_))
     end
 
     # With permutation
@@ -115,18 +126,16 @@ function confusion_matrix(ŷ::Vec{<:CategoricalValue}, y::Vec{<:CategoricalValu
     @inbounds for i in eachindex(y)
         cmat[iperm[int(ŷ[i])], iperm[int(y[i])]] += 1
     end
-    return ConfusionMatrix(cmat, string.(levels_[perm]))
+    return ConfusionMatrixObject(cmat, string.(levels_[perm]))
 end
 
-# synonym
-confmat = confusion_matrix
 
 # Machinery to display the confusion matrix in a non-confusing way
 # (provided the REPL is wide enough)
 
 splitw(w::Int) = (sp1 = div(w, 2); sp2 = w - sp1; (sp1, sp2))
 
-function Base.show(stream::IO, m::MIME"text/plain", cm::ConfusionMatrix{C}
+function Base.show(stream::IO, m::MIME"text/plain", cm::ConfusionMatrixObject{C}
                    ) where C
     width    = displaysize(stream)[2]
     cw       = 13
@@ -183,30 +192,51 @@ function Base.show(stream::IO, m::MIME"text/plain", cm::ConfusionMatrix{C}
 end
 
 
-## MAKE CONFUSION MATRIX A MEASURE
+## CONFUSION MATRIX AS MEASURE
 
-const Confusion = typeof(confusion_matrix)
+struct ConfusionMatrix <: Measure
+    perm::Union{Nothing,Vector{<:Integer}}
+end
 
-is_measure(::Confusion) = true
-is_measure_type(::Type{Confusion}) = true
+ConfusionMatrix(; perm=nothing) = ConfusionMatrix(perm)
 
-MLJModelInterface.name(::Type{Confusion}) = "confusion_matrix"
-MLJModelInterface.target_scitype(::Type{Confusion}) =
+is_measure(::ConfusionMatrix) = true
+is_measure_type(::Type{ConfusionMatrix}) = true
+human_name(::Type{<:ConfusionMatrix}) = "confusion matrix"
+MLJModelInterface.target_scitype(::Type{ConfusionMatrix}) =
     AbstractVector{<:Finite}
-MLJModelInterface.supports_weights(::Type{Confusion}) = false
-MLJModelInterface.prediction_type(::Type{Confusion}) = :deterministic
-MLJModelInterface.docstring(::Type{Confusion}) =
-    "confusion matrix; aliases: confusion_matrix, confmat. "
-orientation(::Type{Confusion}) = :other
-reports_each_observation(::Type{Confusion}) = false
-is_feature_dependent(::Type{Confusion}) = false
-aggregation(::Type{Confusion}) = Sum()
+MLJModelInterface.supports_weights(::Type{ConfusionMatrix}) = false
+MLJModelInterface.prediction_type(::Type{ConfusionMatrix}) = :deterministic
+instances(::Type{<:ConfusionMatrix}) = ["confusion_matrix", "confmat"]
+orientation(::Type{ConfusionMatrix}) = :other
+reports_each_observation(::Type{ConfusionMatrix}) = false
+is_feature_dependent(::Type{ConfusionMatrix}) = false
+aggregation(::Type{ConfusionMatrix}) = Sum()
 
-# aggregation:
-Base.round(m::MLJBase.ConfusionMatrix; kws...) = m
-function Base.:+(m1::ConfusionMatrix, m2::ConfusionMatrix)
+@create_aliases ConfusionMatrix
+
+@create_docs(ConfusionMatrix,
+body=
+"""
+If `r` is the return value, then the raw confusion matrix is `r.mat`,
+whose rows correspond to predictions, and columns to ground truth.
+The ordering follows that of `levels(y)`.
+
+Use `ConfusionMatrix(perm=[2, 1])` to reverse the class order for binary
+data. For more than two classes, specify an appropriate permutation, as in
+`ConfusionMatrix(perm=[2, 3, 1])`.
+""",
+scientific_type=DOC_ORDERED_FACTOR_BINARY)
+
+# calling behaviour:
+(m::ConfusionMatrix)(ŷ::Vec{<:CategoricalValue}, y::Vec{<:CategoricalValue}) =
+    _confmat(ŷ, y, perm=m.perm)
+
+# overloading addition to make aggregation work:
+Base.round(m::MLJBase.ConfusionMatrixObject; kws...) = m
+function Base.:+(m1::ConfusionMatrixObject, m2::ConfusionMatrixObject)
     if m1.labels != m2.labels
         throw(ArgumentError("Confusion matrix labels must agree"))
     end
-    ConfusionMatrix(m1.mat + m2.mat, m1.labels)
+    ConfusionMatrixObject(m1.mat + m2.mat, m1.labels)
 end

--- a/src/measures/continuous.jl
+++ b/src/measures/continuous.jl
@@ -1,31 +1,33 @@
 ## REGRESSOR METRICS (FOR DETERMINISTIC PREDICTIONS)
 
-struct MAE <: Measure end
+# -----------------------------------------------------------
+# MeanAbsoluteError
 
+struct MeanAbsoluteError <: Measure end
+
+metadata_measure(MeanAbsoluteError;
+                 instances = ["mae", "mav", "mean_absolute_error",
+                              "mean_absolute_value"],
+                 target_scitype           = Union{Vec{Continuous},Vec{Count}},
+                 prediction_type          = :deterministic,
+                 orientation              = :loss,
+                 reports_each_observation = false,
+                 is_feature_dependent     = false,
+                 supports_weights         = true)
+
+const MAE = MeanAbsoluteError
+const MAV = MeanAbsoluteError
+@create_aliases MeanAbsoluteError
+
+body =
 """
-    mae(ŷ, y)
-    mae(ŷ, y, w)
-
-Mean absolute error.
-
-``\\text{MAE} =  n^{-1}∑ᵢ|yᵢ-ŷᵢ|`` or ``\\text{MAE} = n^{-1}∑ᵢwᵢ|yᵢ-ŷᵢ|``
-
-For more information, run `info(mae)`.
+``\\text{mean absolute error} =  n^{-1}∑ᵢ|yᵢ-ŷᵢ|`` or
+``\\text{mean absolute error} = n^{-1}∑ᵢwᵢ|yᵢ-ŷᵢ|``
 """
-const mae = MAE()
-const mav = MAE()
+"$(detailed_doc_string(MeanAbsoluteError, body=body))"
+function MeanAbsoluteError end
 
-metadata_measure(MAE;
-    name                     = "mae",
-    target_scitype           = Union{Vec{Continuous},Vec{Count}},
-    prediction_type          = :deterministic,
-    orientation              = :loss,
-    reports_each_observation = false,
-    is_feature_dependent     = false,
-    supports_weights         = true,
-    docstring                = "mean absolute error; aliases: `mae`, `mav`")
-
-function (::MAE)(ŷ::Vec{<:Real}, y::Vec{<:Real})
+function (::MeanAbsoluteError)(ŷ::Vec{<:Real}, y::Vec{<:Real})
     check_dimensions(ŷ, y)
     ret = zero(eltype(y))
     for i in eachindex(y)
@@ -35,7 +37,7 @@ function (::MAE)(ŷ::Vec{<:Real}, y::Vec{<:Real})
     return ret / length(y)
 end
 
-function (::MAE)(ŷ::Vec{<:Real}, y::Vec{<:Real},
+function (::MeanAbsoluteError)(ŷ::Vec{<:Real}, y::Vec{<:Real},
                  w::Vec{<:Real})
     check_dimensions(ŷ, y)
     check_dimensions(y, w)
@@ -47,31 +49,34 @@ function (::MAE)(ŷ::Vec{<:Real}, y::Vec{<:Real},
     return ret / length(y)
 end
 
-struct RMS <: Measure end
+# ----------------------------------------------------------------
+# RootMeanSquaredError
+
+struct RootMeanSquaredError <: Measure end
+
+metadata_measure(RootMeanSquaredError;
+                 instances                = ["rms", "rmse",
+                                             "root_mean_squared_error"],
+                 target_scitype           = Union{Vec{Continuous},Vec{Count}},
+                 prediction_type          = :deterministic,
+                 orientation              = :loss,
+                 reports_each_observation = false,
+                 aggregation              = RootMeanSquare(),
+                 is_feature_dependent     = false,
+                 supports_weights         = true)
+
+const RMS = RootMeanSquaredError()
+@create_aliases RootMeanSquaredError
+
+body =
 """
-    rms(ŷ, y)
-    rms(ŷ, y, w)
-
-Root mean squared error:
-
-``\\text{RMS} = \\sqrt{n^{-1}∑ᵢ|yᵢ-ŷᵢ|^2}`` or ``\\text{RMS} = \\sqrt{\\frac{∑ᵢwᵢ|yᵢ-ŷᵢ|^2}{∑ᵢwᵢ}}``
-
-For more information, run `info(rms)`.
+``\\text{root mean squared error} = \\sqrt{n^{-1}∑ᵢ|yᵢ-ŷᵢ|^2}`` or
+``\\text{root mean squared error} = \\sqrt{\\frac{∑ᵢwᵢ|yᵢ-ŷᵢ|^2}{∑ᵢwᵢ}}``
 """
-const rms = RMS()
+"$(detailed_doc_string(RootMeanSquaredError, body=body))"
+function RootMeanSquaredError end
 
-metadata_measure(RMS;
-    name                     = "rms",
-    target_scitype           = Union{Vec{Continuous},Vec{Count}},
-    prediction_type          = :deterministic,
-    orientation              = :loss,
-    reports_each_observation = false,
-    aggregation              = RootMeanSquare(),
-    is_feature_dependent     = false,
-    supports_weights         = true,
-    docstring                = "root mean squared; aliases: `rms`.")
-
-function (::RMS)(ŷ::Vec{<:Real}, y::Vec{<:Real})
+function (::RootMeanSquaredError)(ŷ::Vec{<:Real}, y::Vec{<:Real})
     check_dimensions(ŷ, y)
     ret = zero(eltype(y))
     for i in eachindex(y)
@@ -81,7 +86,7 @@ function (::RMS)(ŷ::Vec{<:Real}, y::Vec{<:Real})
     return sqrt(ret / length(y))
 end
 
-function (::RMS)(ŷ::Vec{<:Real}, y::Vec{<:Real},
+function (::RootMeanSquaredError)(ŷ::Vec{<:Real}, y::Vec{<:Real},
                  w::Vec{<:Real})
     check_dimensions(ŷ, y)
     ret = zero(eltype(y))
@@ -92,101 +97,74 @@ function (::RMS)(ŷ::Vec{<:Real}, y::Vec{<:Real},
     return sqrt(ret / length(y))
 end
 
-struct L2 <: Measure end
+# -------------------------------------------------------------------
+# LP
 
-"""
-    l2(ŷ, y)
-    l2(ŷ, y, w)
-
-L2 per-observation loss.
-
-For more information, run `info(l2)`.
-"""
-const l2 = L2()
-
-metadata_measure(L2;
-    name                     = "l2",
-    target_scitype           = Union{Vec{Continuous},Vec{Count}},
-    prediction_type          = :deterministic,
-    orientation              = :loss,
-    reports_each_observation = true,
-    is_feature_dependent     = false,
-    supports_weights         = true,
-    docstring                = "squared deviations; aliases: `l2`.")
-
-function (::L2)(ŷ::Vec{<:Real}, y::Vec{<:Real})
-    check_dimensions(ŷ, y)
-    return (y - ŷ).^2
+struct LPLoss <: Measure
+    p::Float64
 end
 
-function (::L2)(ŷ::Vec{<:Real}, y::Vec{<:Real},
+LPLoss(; p=2.0) = LPLoss(p)
+
+metadata_measure(LPLoss;
+                 instances = ["l1", "l2"],
+                 target_scitype           = Union{Vec{Continuous},Vec{Count}},
+                 prediction_type          = :deterministic,
+                 orientation              = :loss,
+                 reports_each_observation = true,
+                 is_feature_dependent     = false,
+                 supports_weights         = true)
+
+const l1 = LPLoss(1)
+const l2 = LPLoss(2)
+
+body=
+"""
+Constructor key-word arguments: `p` (default = 2). Reports
+`|ŷ[i] - y[i]|^p` for every index `i`.
+"""
+"$(detailed_doc_string(LPLoss, body=body))"
+function LPLoss end
+
+function (m::LPLoss)(ŷ::Vec{<:Real}, y::Vec{<:Real})
+    check_dimensions(ŷ, y)
+    return abs.((y - ŷ)).^(m.p)
+end
+
+function (m::LPLoss)(ŷ::Vec{<:Real}, y::Vec{<:Real},
                 w::Vec{<:Real})
     check_dimensions(ŷ, y)
     check_dimensions(w, y)
-    return w .* (y - ŷ).^2
+    return w .* abs.((y - ŷ)).^(m.p)
 end
 
-struct L1 <: Measure end
+# ----------------------------------------------------------------------------
+# RootMeanSquaredLogError
 
+struct RootMeanSquaredLogError <: Measure end
+
+metadata_measure(RootMeanSquaredLogError;
+                 instances = ["rmsl", "rmsle", "root_mean_squared_log_error"],
+                 target_scitype           = Union{Vec{Continuous},Vec{Count}},
+                 prediction_type          = :deterministic,
+                 orientation              = :loss,
+                 reports_each_observation = false,
+                 aggregation              = RootMeanSquare(),
+                 is_feature_dependent     = false,
+                 supports_weights         = false)
+
+const RMSL = RootMeanSquaredLogError
+@create_aliases RootMeanSquaredLogError
+body =
 """
-    l1(ŷ, y)
-    l1(ŷ, y, w)
-
-L1 per-observation loss.
-
-For more information, run `info(l1)`.
+``\\text{root mean squared log error} =
+n^{-1}∑ᵢ\\log\\left({yᵢ \\over ŷᵢ}\\right)``
 """
-const l1 = L1()
+footer = "See also [`rmslp1`](@ref)."
+"$(detailed_doc_string(RootMeanSquaredLogError, body=body, footer=footer))"
+function RootMeanSquaredLogError end
 
-metadata_measure(L1;
-    name                     = "l1",
-    target_scitype           = Union{Vec{Continuous},Vec{Count}},
-    prediction_type          = :deterministic,
-    orientation              = :loss,
-    reports_each_observation = true,
-    is_feature_dependent     = false,
-    supports_weights         = true,
-    docstring                = "absolute deviations; aliases: `l1`.")
-
-function (::L1)(ŷ::Vec{<:Real}, y::Vec{<:Real})
-    check_dimensions(ŷ, y)
-    return abs.(y - ŷ)
-end
-
-function (::L1)(ŷ::Vec{<:Real}, y::Vec{<:Real},
-                w::Vec{<:Real})
-    check_dimensions(ŷ, y)
-    check_dimensions(w, y)
-    return w .* abs.(y - ŷ)
-end
-
-struct RMSL <: Measure end
-
-"""
-    rmsl(ŷ, y)
-
-Root mean squared logarithmic error:
-
-``\\text{RMSL} = n^{-1}∑ᵢ\\log\\left({yᵢ \\over ŷᵢ}\\right)``
-
-For more information, run `info(rmsl)`.
-
-See also [`rmslp1`](@ref).
-"""
-const rmsl = RMSL()
-
-metadata_measure(RMSL;
-    name                     = "rmsl",
-    target_scitype           = Union{Vec{Continuous},Vec{Count}},
-    prediction_type          = :deterministic,
-    orientation              = :loss,
-    reports_each_observation = false,
-    aggregation              = RootMeanSquare(),
-    is_feature_dependent     = false,
-    supports_weights         = false,
-    docstring                = "root mean square logarithm; aliases: `rmsl`.")
-
-function (::RMSL)(ŷ::Vec{<:Real}, y::Vec{<:Real})
+function (::RootMeanSquaredLogError)(ŷ::Vec{<:Real}, y::Vec{<:Real})
     check_dimensions(ŷ, y)
     ret = zero(eltype(y))
     for i in eachindex(y)
@@ -196,76 +174,94 @@ function (::RMSL)(ŷ::Vec{<:Real}, y::Vec{<:Real})
     return sqrt(ret / length(y))
 end
 
-struct RMSLP1 <: Measure end
+# ---------------------------------------------------------------------------
+#  RootMeanSquaredLogProportionalError
+
+struct RootMeanSquaredLogProportionalError <: Measure
+    offset::Float64
+end
+
+RootMeanSquaredLogProportionalError(; offset=1.0) =
+    RootMeanSquaredLogProportionalError(offset)
+
+metadata_measure(RootMeanSquaredLogProportionalError;
+                 instances                = ["rmslp1", ],
+                 target_scitype           = Union{Vec{Continuous},Vec{Count}},
+                 prediction_type          = :deterministic,
+                 orientation              = :loss,
+                 reports_each_observation = false,
+                 aggregation              = RootMeanSquare(),
+                 is_feature_dependent     = false,
+                 supports_weights         = false)
+
+const RMSLP = RootMeanSquaredLogProportionalError
+@create_aliases RootMeanSquaredLogProportionalError
+
+body =
 """
-    rmslp1(ŷ, y)
+Constructor key-word arguments: `offset` (default = 1.0).
 
-Root mean squared logarithmic error with an offset of 1:
-
-``\\text{RMSLP1} = n^{-1}∑ᵢ\\log\\left({yᵢ + 1 \\over ŷᵢ + 1}\\right)``
-
-For more information, run `info(rmslp1)`.
-
-See also [`rmsl`](@ref).
+``\\text{root mean squared log proportional error} =
+n^{-1}∑ᵢ\\log\\left({yᵢ + \\text{offset} \\over ŷᵢ + \\text{offset}}\\right)``
 """
-const rmslp1 = RMSLP1()
+footer = "See also [`rmsl`](@ref). "
+"$(detailed_doc_string(RMSLP, body=body, footer=footer))"
+function RootMeanSquaredLogProportionalError end
 
-metadata_measure(RMSLP1;
-    name                     = "rmslp1",
-    target_scitype           = Union{Vec{Continuous},Vec{Count}},
-    prediction_type          = :deterministic,
-    orientation              = :loss,
-    reports_each_observation = false,
-    aggregation              = RootMeanSquare(),
-    is_feature_dependent     = false,
-    supports_weights         = false,
-    docstring                = "root mean squared logarithm plus one; " *
-                               "aliases: `rmslp1`.")
-
-function (::RMSLP1)(ŷ::Vec{<:Real}, y::Vec{<:Real})
+function (m::RMSLP)(ŷ::Vec{<:Real}, y::Vec{<:Real})
     check_dimensions(ŷ, y)
     ret = zero(eltype(y))
     for i in eachindex(y)
-        dev = (log(y[i] + 1) - log(ŷ[i] + 1))^2
+        dev = (log(y[i] + m.offset) - log(ŷ[i] + m.offset))^2
         ret += dev
     end
     return sqrt(ret / length(y))
 end
 
-struct RMSP <: Measure end
+# --------------------------------------------------------------------------
+# RootMeanSquaredProportionalError
 
-"""
-    rmsp(ŷ, y)
+struct RootMeanSquaredProportionalError <: Measure
+    tol::Float64
+end
 
-Root mean squared proportional loss:
+RootMeanSquaredProportionalError(; tol=eps()) =
+    RootMeanSquaredProportionalError(tol)
 
-``\\text{RMSP} = m^{-1}∑ᵢ \\left({yᵢ-ŷᵢ \\over yᵢ}\\right)^2``
-
-where the sum is over indices such that `yᵢ≂̸0` and `m` is the number
-of such indices.
-
-For more information, run `info(rmsp)`.
-"""
-const rmsp = RMSP()
-
-metadata_measure(RMSP;
-    name                     = "rmsp",
+metadata_measure(RootMeanSquaredProportionalError;
+    instances                = ["rmsp", ],
     target_scitype           = Union{Vec{Continuous},Vec{Count}},
     prediction_type          = :deterministic,
     orientation              = :loss,
     reports_each_observation = false,
     aggregation              = RootMeanSquare(),
     is_feature_dependent     = false,
-    supports_weights         = false,
-    docstring                = "root mean square proportions; aliases: `rmsp`.")
+    supports_weights         = false)
 
-function (::RMSP)(ŷ::Vec{<:Real}, y::Vec{<:Real}, tol=eps())
+const RMSP = RootMeanSquaredProportionalError
+@create_aliases RMSP
+
+body =
+"""
+Constructor keyword arguments: `tol` (default = `eps()`).
+
+``\\text{root mean squared proportional error} =
+m^{-1}∑ᵢ \\left({yᵢ-ŷᵢ \\over yᵢ}\\right)^2``
+
+where the sum is over indices such that `abs(yᵢ) > tol` and `m` is the number
+of such indices.
+
+"""
+"$(detailed_doc_string(RMSP, body=body))"
+function RootMeanSquaredProportionalError end
+
+function (m::RootMeanSquaredProportionalError)(ŷ::Vec{<:Real}, y::Vec{<:Real})
     check_dimensions(ŷ, y)
     ret = zero(eltype(y))
     count = 0
     @inbounds for i in eachindex(y)
         ayi = abs(y[i])
-        if ayi > tol
+        if ayi > m.tol
             dev = ((y[i] - ŷ[i]) / ayi)^2
             ret += dev
             count += 1
@@ -274,27 +270,17 @@ function (::RMSP)(ŷ::Vec{<:Real}, y::Vec{<:Real}, tol=eps())
     return sqrt(ret / count)
 end
 
-struct MAPE <: Measure
-    tol::Real
+# -----------------------------------------------------------------------
+# MeanAbsoluteProportionalError
+
+struct MeanAbsoluteProportionalError <: Measure
+    tol::Float64
 end
 
-MAPE(; tol=eps()) = MAPE(tol)
+MeanAbsoluteProportionalError(; tol=eps()) = MeanAbsoluteProportionalError(tol)
 
-"""
-     MAPE(; tol=esp())
-
-Mean Absolute Proportional Error:
-
-``\\text{MAPE} =  m^{-1}∑ᵢ|{(yᵢ-ŷᵢ) \\over yᵢ}|``
-where the sum is over indices such that `yᵢ > tol` and `m` is the number
-of such indices.
-
-For more information, run `info(mape)`.
-"""
-const mape = MAPE()
-
-metadata_measure(MAPE;
-    name                     = "mape",
+metadata_measure(MeanAbsoluteProportionalError;
+    instances                = ["mape", ],
     target_scitype           = Union{Vec{Continuous},Vec{Count}},
     prediction_type          = :deterministic,
     orientation              = :loss,
@@ -304,7 +290,22 @@ metadata_measure(MAPE;
     docstring                = "Mean Absolute Proportional Error; "*
                  "aliases: `mape=MAPE()`.")
 
-function (m::MAPE)(ŷ::Vec{<:Real}, y::Vec{<:Real})
+const MAPE = MeanAbsoluteProportionalError
+@create_aliases MAPE
+
+body=
+"""
+Constructor key-word arguments: `tol` (default = `eps()`).
+
+``\\text{mean absolute proportional error} =  m^{-1}∑ᵢ|{(yᵢ-ŷᵢ) \\over yᵢ}|``
+
+where the sum is over indices such that `abs(yᵢ) > tol` and `m` is the number
+of such indices.
+"""
+"$(detailed_doc_string(MAPE, body=body))"
+function MeanAbsoluteProportionalError end
+
+function (m::MeanAbsoluteProportionalError)(ŷ::Vec{<:Real}, y::Vec{<:Real})
     check_dimensions(ŷ, y)
     ret = zero(eltype(y))
     count = 0
@@ -321,23 +322,13 @@ function (m::MAPE)(ŷ::Vec{<:Real}, y::Vec{<:Real})
     return ret / count
 end
 
-struct LogCosh <: Measure end
+# -------------------------------------------------------------------------
+# LogCoshLoss
 
-"""
-    log_cosh(ŷ, y)
+struct LogCoshLoss <: Measure end
 
-Log-Cosh per-observation loss:
-
-``\\text{Log-Cosh Loss} = log(cosh(ŷᵢ-yᵢ))``
-
-where `yᵢ` is the target and `ŷᵢ` is the output.
-
-For more information, run `info(log_cosh)`.
-"""
-const log_cosh = LogCosh()
-
-metadata_measure(LogCosh;
-    name                     = "log_cosh",
+metadata_measure(LogCoshLoss;
+    instances                = ["log_cosh", "log_cosh_loss"],
     target_scitype           = Union{Vec{Continuous},Vec{Count}},
     prediction_type          = :deterministic,
     orientation              = :loss,
@@ -346,10 +337,17 @@ metadata_measure(LogCosh;
     supports_weights         = false,
     docstring                = "log cosh loss; aliases: `log_cosh`.")
 
+const LogCosh = LogCoshLoss
+@create_aliases LogCoshLoss
+
+body = "Reports ``\\log(\\cosh(ŷᵢ-yᵢ))`` for each index `i`. "
+"$(detailed_doc_string(LogCoshLoss, body=body))"
+function LogCoshLoss end
+
 _softplus(x::T) where T<:Real = x > zero(T) ? x + log1p(exp(-x)) : log1p(exp(x))
 _log_cosh(x::T) where T<:Real = x + _softplus(-2x) - log(convert(T, 2))
 
-function (log_cosh::LogCosh)(ŷ::Vec{<:T}, y::Vec{<:T}) where T <:Real
+function (log_cosh::LogCoshLoss)(ŷ::Vec{<:T}, y::Vec{<:T}) where T <:Real
     check_dimensions(ŷ, y)
     return _log_cosh.(ŷ - y)
 end

--- a/src/measures/continuous.jl
+++ b/src/measures/continuous.jl
@@ -1,5 +1,3 @@
-const DOC_CONTINUOUS = "`AbstractArray{Continuous}` (regression)"
-
 # ===========================================================
 ## DETERMINISTIC PREDICTIONS
 

--- a/src/measures/continuous.jl
+++ b/src/measures/continuous.jl
@@ -99,8 +99,8 @@ end
 # -------------------------------------------------------------------
 # LP
 
-struct LPLoss <: Measure
-    p::Float64
+struct LPLoss{T<:Real} <: Measure
+    p::T
 end
 
 LPLoss(; p=2.0) = LPLoss(p)
@@ -175,8 +175,8 @@ end
 # ---------------------------------------------------------------------------
 #  RootMeanSquaredLogProportionalError
 
-struct RootMeanSquaredLogProportionalError <: Measure
-    offset::Float64
+struct RootMeanSquaredLogProportionalError{T<:Real} <: Measure
+    offset::T
 end
 
 RootMeanSquaredLogProportionalError(; offset=1.0) =
@@ -218,8 +218,8 @@ end
 # --------------------------------------------------------------------------
 # RootMeanSquaredProportionalError
 
-struct RootMeanSquaredProportionalError <: Measure
-    tol::Float64
+struct RootMeanSquaredProportionalError{T<:Real} <: Measure
+    tol::T
 end
 
 RootMeanSquaredProportionalError(; tol=eps()) =
@@ -269,8 +269,8 @@ end
 # -----------------------------------------------------------------------
 # MeanAbsoluteProportionalError
 
-struct MeanAbsoluteProportionalError <: Measure
-    tol::Float64
+struct MeanAbsoluteProportionalError{T} <: Measure
+    tol::T
 end
 
 MeanAbsoluteProportionalError(; tol=eps()) = MeanAbsoluteProportionalError(tol)

--- a/src/measures/continuous.jl
+++ b/src/measures/continuous.jl
@@ -1,4 +1,7 @@
-## REGRESSOR METRICS (FOR DETERMINISTIC PREDICTIONS)
+const DOC_CONTINUOUS = "`AbstractArray{Continuous}` (regression)"
+
+# ===========================================================
+## DETERMINISTIC PREDICTIONS
 
 # -----------------------------------------------------------
 # MeanAbsoluteError
@@ -19,13 +22,12 @@ const MAE = MeanAbsoluteError
 const MAV = MeanAbsoluteError
 @create_aliases MeanAbsoluteError
 
-body =
+@create_docs(MeanAbsoluteError,
+body=
 """
 ``\\text{mean absolute error} =  n^{-1}∑ᵢ|yᵢ-ŷᵢ|`` or
 ``\\text{mean absolute error} = n^{-1}∑ᵢwᵢ|yᵢ-ŷᵢ|``
-"""
-"$(detailed_doc_string(MeanAbsoluteError, body=body))"
-function MeanAbsoluteError end
+""")
 
 function (::MeanAbsoluteError)(ŷ::Vec{<:Real}, y::Vec{<:Real})
     check_dimensions(ŷ, y)
@@ -65,16 +67,15 @@ metadata_measure(RootMeanSquaredError;
                  is_feature_dependent     = false,
                  supports_weights         = true)
 
-const RMS = RootMeanSquaredError()
+const RMS = RootMeanSquaredError
 @create_aliases RootMeanSquaredError
 
-body =
+@create_docs(RootMeanSquaredError,
+body=
 """
 ``\\text{root mean squared error} = \\sqrt{n^{-1}∑ᵢ|yᵢ-ŷᵢ|^2}`` or
 ``\\text{root mean squared error} = \\sqrt{\\frac{∑ᵢwᵢ|yᵢ-ŷᵢ|^2}{∑ᵢwᵢ}}``
-"""
-"$(detailed_doc_string(RootMeanSquaredError, body=body))"
-function RootMeanSquaredError end
+""")
 
 function (::RootMeanSquaredError)(ŷ::Vec{<:Real}, y::Vec{<:Real})
     check_dimensions(ŷ, y)
@@ -118,13 +119,12 @@ metadata_measure(LPLoss;
 const l1 = LPLoss(1)
 const l2 = LPLoss(2)
 
+@create_docs(LPLoss,
 body=
 """
-Constructor key-word arguments: `p` (default = 2). Reports
+Constructor signature: `LPLoss(p=2)`. Reports
 `|ŷ[i] - y[i]|^p` for every index `i`.
-"""
-"$(detailed_doc_string(LPLoss, body=body))"
-function LPLoss end
+""")
 
 function (m::LPLoss)(ŷ::Vec{<:Real}, y::Vec{<:Real})
     check_dimensions(ŷ, y)
@@ -155,14 +155,14 @@ metadata_measure(RootMeanSquaredLogError;
 
 const RMSL = RootMeanSquaredLogError
 @create_aliases RootMeanSquaredLogError
-body =
+
+@create_docs(RootMeanSquaredLogError,
+body=
 """
 ``\\text{root mean squared log error} =
 n^{-1}∑ᵢ\\log\\left({yᵢ \\over ŷᵢ}\\right)``
-"""
-footer = "See also [`rmslp1`](@ref)."
-"$(detailed_doc_string(RootMeanSquaredLogError, body=body, footer=footer))"
-function RootMeanSquaredLogError end
+""",
+footer="See also [`rmslp1`](@ref).")
 
 function (::RootMeanSquaredLogError)(ŷ::Vec{<:Real}, y::Vec{<:Real})
     check_dimensions(ŷ, y)
@@ -197,16 +197,15 @@ metadata_measure(RootMeanSquaredLogProportionalError;
 const RMSLP = RootMeanSquaredLogProportionalError
 @create_aliases RootMeanSquaredLogProportionalError
 
-body =
+@create_docs(RootMeanSquaredLogProportionalError,
+body=
 """
-Constructor key-word arguments: `offset` (default = 1.0).
+Constructor signature: `RootMeanSquaredLogProportionalError(; offset = 1.0)`.
 
 ``\\text{root mean squared log proportional error} =
 n^{-1}∑ᵢ\\log\\left({yᵢ + \\text{offset} \\over ŷᵢ + \\text{offset}}\\right)``
-"""
-footer = "See also [`rmsl`](@ref). "
-"$(detailed_doc_string(RMSLP, body=body, footer=footer))"
-function RootMeanSquaredLogProportionalError end
+""",
+footer="See also [`rmsl`](@ref). ")
 
 function (m::RMSLP)(ŷ::Vec{<:Real}, y::Vec{<:Real})
     check_dimensions(ŷ, y)
@@ -241,7 +240,8 @@ metadata_measure(RootMeanSquaredProportionalError;
 const RMSP = RootMeanSquaredProportionalError
 @create_aliases RMSP
 
-body =
+@create_docs(RootMeanSquaredProportionalError,
+body=
 """
 Constructor keyword arguments: `tol` (default = `eps()`).
 
@@ -251,9 +251,7 @@ m^{-1}∑ᵢ \\left({yᵢ-ŷᵢ \\over yᵢ}\\right)^2``
 where the sum is over indices such that `abs(yᵢ) > tol` and `m` is the number
 of such indices.
 
-"""
-"$(detailed_doc_string(RMSP, body=body))"
-function RootMeanSquaredProportionalError end
+""")
 
 function (m::RootMeanSquaredProportionalError)(ŷ::Vec{<:Real}, y::Vec{<:Real})
     check_dimensions(ŷ, y)
@@ -293,6 +291,7 @@ metadata_measure(MeanAbsoluteProportionalError;
 const MAPE = MeanAbsoluteProportionalError
 @create_aliases MAPE
 
+@create_docs(MeanAbsoluteProportionalError,
 body=
 """
 Constructor key-word arguments: `tol` (default = `eps()`).
@@ -301,9 +300,7 @@ Constructor key-word arguments: `tol` (default = `eps()`).
 
 where the sum is over indices such that `abs(yᵢ) > tol` and `m` is the number
 of such indices.
-"""
-"$(detailed_doc_string(MAPE, body=body))"
-function MeanAbsoluteProportionalError end
+""")
 
 function (m::MeanAbsoluteProportionalError)(ŷ::Vec{<:Real}, y::Vec{<:Real})
     check_dimensions(ŷ, y)
@@ -340,9 +337,8 @@ metadata_measure(LogCoshLoss;
 const LogCosh = LogCoshLoss
 @create_aliases LogCoshLoss
 
-body = "Reports ``\\log(\\cosh(ŷᵢ-yᵢ))`` for each index `i`. "
-"$(detailed_doc_string(LogCoshLoss, body=body))"
-function LogCoshLoss end
+@create_docs(LogCoshLoss,
+body="Reports ``\\log(\\cosh(ŷᵢ-yᵢ))`` for each index `i`. ")
 
 _softplus(x::T) where T<:Real = x > zero(T) ? x + log1p(exp(-x)) : log1p(exp(x))
 _log_cosh(x::T) where T<:Real = x + _softplus(-2x) - log(convert(T, 2))

--- a/src/measures/finite.jl
+++ b/src/measures/finite.jl
@@ -37,7 +37,7 @@ the score for that example is given by
 
 A score is reported for every observation.
 """,
-scientific_type=DOC_FINITE)
+scitype=DOC_FINITE)
 
 # for single observation:
 _cross_entropy(d::UnivariateFinite{S,V,R,P}, y, tol) where {S,V,R,P} =
@@ -92,7 +92,7 @@ despite the name. Moreover, the present implementation does not treat
 the binary case as special, so that the score may differ, in that
 case, by a factor of two from usage elsewhere.
 """,
-scientific_type=DOC_FINITE)
+scitype=DOC_FINITE)
 
 # calling on single observations (no checks):
 function _brier_score(d::UnivariateFinite{S,V,R,P}, y) where {S,V,R,P}
@@ -176,7 +176,7 @@ positive).  Note also the present implementation does not treat the
 binary case as special, so that the loss may differ, in that case, by
 a factor of two from usage elsewhere.
 """,
-scientific_type=DOC_FINITE)
+scitype=DOC_FINITE)
 
 # calling on single observations (no checks):
 function _brier_loss(d::UnivariateFinite{S,V,R,P}, y) where {S,V,R,P}
@@ -225,7 +225,7 @@ body=
 A confusion matrix can also be passed as argument.
 $INVARIANT_LABEL
 """,
-scientific_type=DOC_FINITE)
+scitype=DOC_FINITE)
 
 # calling behaviour:
 (::MCR)(ŷ::Vec{<:CategoricalValue},
@@ -257,7 +257,7 @@ body=
 Accuracy is proportion of correct predictions `ŷ[i]` that match the
 ground truth `y[i]` observations. $INVARIANT_LABEL
 """,
-scientific_type=DOC_FINITE)
+scitype=DOC_FINITE)
 
 # calling behaviour:
 (::Accuracy)(args...) = 1.0 - misclassification_rate(args...)
@@ -287,7 +287,7 @@ Balanced accuracy compensates standard [`Accuracy`](@ref) for class imbalance.
 See [https://en.wikipedia.org/wiki/Precision_and_recall#Imbalanced_data](https://en.wikipedia.org/wiki/Precision_and_recall#Imbalanced_data).
 $INVARIANT_LABEL
 """,
-scientific_type=DOC_FINITE)
+scitype=DOC_FINITE)
 
 # calling behavior:
 function (::BACC)(ŷ::Vec{<:CategoricalValue},
@@ -333,7 +333,7 @@ body=
 [https://en.wikipedia.org/wiki/Matthews_correlation_coefficient](https://en.wikipedia.org/wiki/Matthews_correlation_coefficient)
 $INVARIANT_LABEL
 """,
-scientific_type=DOC_FINITE_BINARY)
+scitype=DOC_FINITE_BINARY)
 
 # calling behaviour:
 function (::MCC)(cm::ConfusionMatrixObject{C}) where C
@@ -465,7 +465,7 @@ Constructor signature: `FScore(; β=1.0, rev=true)`.
 By default, the second element of `levels(y)` is designated as
 `true`. To reverse roles, specify `rev=true`.
 """,
-scientific_type=DOC_ORDERED_FACTOR_BINARY,
+scitype=DOC_ORDERED_FACTOR_BINARY,
 footer="Constructor signature: `FScore(β=1.0, rev=false)`. ")
 
 # calling on conf matrix:
@@ -587,7 +587,7 @@ for M in TRUE_POSITIVE_AND_COUSINS
          Assigns `false` to first element of `levels(y)`. To reverse roles,
          use `$(name($M))(rev=true)`.
          """,
-         scientific_type=DOC_ORDERED_FACTOR_BINARY)
+         scitype=DOC_ORDERED_FACTOR_BINARY)
          end)
 end
 

--- a/src/measures/finite.jl
+++ b/src/measures/finite.jl
@@ -1,67 +1,68 @@
-# ---------------------------------------------------
-## CLASSIFICATION METRICS (PROBABILISTIC PREDICTIONS)
-# >> CrossEntropy
-# >> BriersScore
+const DOC_FINITE =
+    "`AbstractArray{<:Finite}` (multiclass classification)"
+const DOC_FINITE_BINARY =
+    "`AbstractArray{<:Finite{2}}` (binary classification)"
+const DOC_ORDERED_FACTOR =
+    "`AbstractArray{<:OrderedFactor}` (classification of ordered target)"
+const DOC_ORDERED_FACTOR_BINARY =
+    "`AbstractArray{<:OrderedFactor{2}}` "*
+    "(binary classification where choice of \"true\" effects the measure)"
+
+
+# ============================================================
+# PROBABILISTIC PREDICTIONS
 
 # -----------------------------------------------------
-# cross entropy
+# LogLoss
 
-struct CrossEntropy{R} <: Measure where R <: AbstractFloat
+struct LogLoss{R} <: Measure where R <: Real
     eps::R
 end
-CrossEntropy(;eps=eps()) = CrossEntropy(eps)
+LogLoss(;eps=eps()) = LogLoss(eps)
 
-metadata_measure(CrossEntropy;
-    name                     = "cross_entropy",
-    target_scitype           = Vec{<:Finite},
-    prediction_type          = :probabilistic,
-    orientation              = :loss,
-    reports_each_observation = true,
-    is_feature_dependent     = false,
-    supports_weights         = false,
-    docstring                = "Cross entropy loss with probabilities " *
-                 "clamped between `eps()` and `1-eps()`; "*
-                 "aliases: `cross_entropy`.",
-    distribution_type        = UnivariateFinite)
+metadata_measure(LogLoss;
+                 instances                = ["log_loss", "cross_entropy"],
+                 target_scitype           = Vec{<:Finite},
+                 prediction_type          = :probabilistic,
+                 orientation              = :loss,
+                 reports_each_observation = true,
+                 is_feature_dependent     = false,
+                 supports_weights         = false,
+                 distribution_type        = UnivariateFinite)
 
+const CrossEntropy = LogLoss
+@create_aliases LogLoss
+
+@create_docs(LogLoss,
+body=
 """
-    cross_entropy
-
-$(docstring(CrossEntropy()))
-
-    ce = CrossEntropy(; eps=eps())
-    ce(ŷ, y)
-
-Given an abstract vector of distributions `ŷ` and an abstract vector
-of true observations `y`, return the corresponding cross-entropy
-loss (aka log loss) scores.
-
-Since the score is undefined in the case of the true observation has
-predicted probability zero, probablities are clipped between `eps` and
-`1-eps` where `eps` can be specified.
+Since the score is undefined in the case that the true observation is
+predicted to occur with probability zero, probablities are clipped
+between `eps` and `1-eps`, where `eps` is a constructor key-word
+argument.
 
 If `sᵢ` is the predicted probability for the true class `yᵢ` then
 the score for that example is given by
 
-    -log(clamp(sᵢ, eps, 1-eps))
+    -log(clamp(sᵢ, eps), 1 - eps)
 
-For more information, run `info(cross_entropy)`.
-"""
-cross_entropy = CrossEntropy()
+A score is reported for every observation.
+""",
+scientific_type=DOC_FINITE)
 
 # for single observation:
 _cross_entropy(d::UnivariateFinite{S,V,R,P}, y, eps) where {S,V,R,P} =
     -log(clamp(pdf(d, y), P(eps), P(1) - P(eps)))
 
 # multiple observations:
-function (c::CrossEntropy)(ŷ::Vec{<:UnivariateFinite},
+function (c::LogLoss)(ŷ::Vec{<:UnivariateFinite},
                            y::Vec)
     check_dimensions(ŷ, y)
     check_pools(ŷ, y)
     return broadcast(_cross_entropy, ŷ, y, c.eps)
 end
 # performant in case of UnivariateFiniteArray:
-function (c::CrossEntropy)(ŷ::UnivariateFiniteVector{S,V,R,P},
+function (c::LogLoss)(ŷ::UnivariateFiniteVector{S,V,R,P},
                            y::Vec) where {S,V,R,P}
     check_dimensions(ŷ, y)
     check_pools(ŷ, y)
@@ -69,75 +70,42 @@ function (c::CrossEntropy)(ŷ::UnivariateFiniteVector{S,V,R,P},
 end
 
 # -----------------------------------------------------
-# brier score
+# BrierScore
 
-# TODO: support many distributions/samplers D below:
+struct BrierScore <: Measure end
 
-struct BrierScore{D} <: Measure end
+metadata_measure(BrierScore;
+                 human_name = "Brier score (a.k.a. quadratic score)",
+                 instances                = ["brier_score",],
+                 target_scitype           = Vec{<:Finite},
+                 prediction_type          = :probabilistic,
+                 orientation              = :score,
+                 reports_each_observation = true,
+                 is_feature_dependent     = false,
+                 supports_weights         = true,
+                 distribution_type        = UnivariateFinite)
 
-# As this measure is parametric, the use of `metadata_measure` is not
-# appropriate.
+@create_aliases BrierScore
 
-MLJModelInterface.name(::Type{<:BrierScore{D}}) where D =
-    "BrierScore{$(string(D))}"
-MLJModelInterface.docstring(::Type{<:BrierScore{D}}) where D =
-    "Brier proper scoring rule for distributions of type $D; "*
-    "aliases: `BrierScore{$D}`"
-MLJModelInterface.docstring(::Type{<:BrierScore{<:UnivariateFinite}}) =
-    "Brier proper scoring rule for `MultiClass` or `OrderedFactor` data; "*
-    "aliases: `BrierScore()`, `BrierScore{UnivariateFinite}`"
-MLJModelInterface.docstring(::Type{BrierScore}) =
-    "Brier proper scoring rule for various distribution types; " *
-    "use `brier_score` for `BrierScore{UnivariateFinite}` "*
-"(`Multiclass` or `OrderedFactor` targets)."
-MLJModelInterface.target_scitype(::Type{<:BrierScore{D}}) where D =
-    AbstractVector{<:Finite}
-MLJModelInterface.prediction_type(::Type{<:BrierScore}) = :probabilistic
-orientation(::Type{<:BrierScore}) = :score
-reports_each_observation(::Type{<:BrierScore}) = true
-is_feature_dependent(::Type{<:BrierScore}) = false
-MLJModelInterface.supports_weights(::Type{<:BrierScore}) =  true
-distribution_type(::Type{<:BrierScore{D}}) where D =
-    UnivariateFinite
-
+@create_docs(BrierScore,
+body=
 """
-    BrierScore(; distribution=UnivariateFinite)(ŷ, y [, w])
-
-Given an abstract vector of distributions `ŷ` of type `distribution`,
-and an abstract vector of true observations `y`, return the
-corresponding Brier (aka quadratic) scores. Weight the scores using
-`w` if provided.
-
-Currently only `distribution=UnivariateFinite` is supported, which is
-applicable to superivised models with `Finite` target scitype. In this
-case, if `p(y)` is the predicted probability for a *single*
+If `p(y)` is the predicted probability for a *single*
 observation `y`, and `C` all possible classes, then the corresponding
 Brier score for that observation is given by
 
 ``2p(y) - \\left(\\sum_{η ∈ C} p(η)^2\\right) - 1``
 
-Note that `BrierScore()=BrierScore{UnivariateFinite}` has the alias
-`brier_score`.
-
-*Warning.* Here `BrierScore` is a "score" in the sense that bigger is
+*Warning.* `BrierScore()` is a "score" in the sense that bigger is
 better (with `0` optimal, and all other values negative). In Brier's
 original 1950 paper, and many other places, it has the opposite sign,
 despite the name. Moreover, the present implementation does not treat
 the binary case as special, so that the score may differ, in that
 case, by a factor of two from usage elsewhere.
+""",
+scientific_type=DOC_FINITE)
 
-For more information, run `info(BrierScore)`.
-
-"""
-function BrierScore(; distribution=UnivariateFinite)
-    distribution == UnivariateFinite ||
-        error("Only `UnivariateFinite` Brier scores currently supported. ")
-    return BrierScore{distribution}()
-end
-
-# For single observations (no checks):
-
-# UnivariateFinite:
+# calling on single observations (no checks):
 function _brier_score(d::UnivariateFinite{S,V,R,P}, y) where {S,V,R,P}
     levels = classes(d)
     pvec = broadcast(pdf, d, levels)
@@ -145,14 +113,10 @@ function _brier_score(d::UnivariateFinite{S,V,R,P}, y) where {S,V,R,P}
     return P(2) * pdf(d, y) - offset
 end
 
-# For multiple observations:
-
-# UnivariateFinite:
-function (::BrierScore{<:UnivariateFinite})(
-    ŷ::Vec{<:UnivariateFinite},
-    y::Vec,
-    w::Union{Nothing,Vec{<:Real}}=nothing)
-
+# calling on multiple observations:
+function (::BrierScore)(ŷ::Vec{<:UnivariateFinite},
+                        y::Vec,
+                        w::Union{Nothing,Vec{<:Real}}=nothing)
     check_dimensions(ŷ, y)
     w == nothing || check_dimensions(w, y)
 
@@ -164,8 +128,9 @@ function (::BrierScore{<:UnivariateFinite})(
     end
     return w.*unweighted
 end
-# performant version in case of UnivariateFiniteArray:
-function (::BrierScore{<:UnivariateFinite})(
+
+# Performant version in case of UnivariateFiniteArray:
+function (::BrierScore)(
     ŷ::UnivariateFiniteVector{S,V,R,P},
     y::Vec,
     w::Union{Nothing,Vec{<:Real}}=nothing) where {S,V,R,P<:Real}
@@ -188,18 +153,65 @@ function (::BrierScore{<:UnivariateFinite})(
     return w.*unweighted
 end
 
-const brier_score = BrierScore()
+# -----------------------------------------------------
+# BrierLoss
+
+struct BrierLoss <: Measure end
+
+metadata_measure(BrierLoss;
+                 human_name = "Brier loss (a.k.a. quadratic loss)",
+                 instances                = ["brier_loss",],
+                 target_scitype           = Vec{<:Finite},
+                 prediction_type          = :probabilistic,
+                 orientation              = :score,
+                 reports_each_observation = true,
+                 is_feature_dependent     = false,
+                 supports_weights         = true,
+                 distribution_type        = UnivariateFinite)
+
+@create_aliases BrierLoss
+
+@create_docs(BrierLoss,
+body=
+"""
+If `p(y)` is the predicted probability for a *single*
+observation `y`, and `C` all possible classes, then the corresponding
+Brier score for that observation is given by
+
+``\\left(\\sum_{η ∈ C} p(η)^2\\right) - 2p(y) + 1``
+
+*Warning.* In Brier's original 1950 paper, what is implemented here is
+called a "loss". It is, however, a "score" in the contemporary use of
+that term: smaller is better (with `0` optimal, and all other values
+positive).  Note also the present implementation does not treat the
+binary case as special, so that the loss may differ, in that case, by
+a factor of two from usage elsewhere.
+""",
+scientific_type=DOC_FINITE)
+
+# calling on single observations (no checks):
+function _brier_loss(d::UnivariateFinite{S,V,R,P}, y) where {S,V,R,P}
+    levels = classes(d)
+    pvec = broadcast(pdf, d, levels)
+    offset = P(1) + sum(pvec.^2)
+    return P(2) * pdf(d, y) - offset
+end
+
+(m::BrierLoss)(ŷ::Vec{<:UnivariateFinite},
+               y::Vec,
+               w::Union{Nothing,Vec{<:Real}}=nothing) =
+                   - brier_score(ŷ, y, w)
 
 
-# ============================================================
-## CLASSIFICATION METRICS (DETERMINISTIC PREDICTIONS)
 
-const INVARIANT_LABEL_MULTICLASS = "This metric is invariant to class labelling and can be used for multiclass classification."
-const INVARIANT_LABEL_BINARY = "This metric is invariant to class labelling and can be used only for binary classification."
-const VARIANT_LABEL_BINARY = "This metric is labelling-dependent and can only be used for binary classification."
 
-# ==============================================================
-## MULTICLASS
+const INVARIANT_LABEL =
+    "This metric is invariant to class reordering."
+const VARIANT_LABEL =
+    "This metric is *not* invariant to class re-ordering"
+
+# =============================================================
+# DETERMINISTIC FINITE PREDICTIONS
 
 # ---------------------------------------------------
 # misclassification rate
@@ -207,45 +219,31 @@ const VARIANT_LABEL_BINARY = "This metric is labelling-dependent and can only be
 struct MisclassificationRate <: Measure end
 
 metadata_measure(MisclassificationRate;
-    name                     = "misclassification_rate",
-    target_scitype           = Vec{<:Finite},
-    prediction_type          = :deterministic,
-    orientation              = :loss,
-    reports_each_observation = false,
-    is_feature_dependent     = false,
-    supports_weights         = true,
-    docstring                = "misclassification rate; aliases: " *
-                               "`misclassification_rate`, `mcr`.")
+                 instances  = ["misclassification_rate", "mcr"],
+                 target_scitype           = Vec{<:Finite},
+                 prediction_type          = :deterministic,
+                 orientation              = :loss,
+                 reports_each_observation = false,
+                 is_feature_dependent     = false,
+                 supports_weights         = true)
 
-"""
-    misclassification_rate
-
-$(docstring(MisclassificationRate()))
-
-    misclassification_rate(ŷ, y)
-    misclassification_rate(ŷ, y, w)
-    misclassification_rate(conf_mat)
-
-Returns the rate of misclassification of the (point) predictions `ŷ`,
-given true observations `y`, optionally weighted by the weights
-`w`. All three arguments must be abstract vectors of the same length.
-A confusion matrix can also be passed as argument.
-$INVARIANT_LABEL_MULTICLASS
-
-For more information, run `info(misclassification_rate)`.
-
-"""
-const misclassification_rate = MisclassificationRate()
-const mcr = misclassification_rate
 const MCR = MisclassificationRate
+@create_aliases MCR
 
+@create_docs(MisclassificationRate,
+body=
+"""
+A confusion matrix can also be passed as argument.
+$INVARIANT_LABEL
+""",
+scientific_type=DOC_FINITE)
+
+# calling behaviour:
 (::MCR)(ŷ::Vec{<:CategoricalValue},
         y::Vec{<:CategoricalValue}) = mean(y .!= ŷ)
-
 (::MCR)(ŷ::Vec{<:CategoricalValue},
         y::Vec{<:CategoricalValue},
         w::Vec{<:Real}) = sum((y .!= ŷ) .* w) / length(y)
-
 (::MCR)(cm::ConfusionMatrix) = 1.0 - sum(diag(cm.mat)) / sum(cm.mat)
 
 # -------------------------------------------------------------
@@ -254,37 +252,27 @@ const MCR = MisclassificationRate
 struct Accuracy <: Measure end
 
 metadata_measure(Accuracy;
-    name                     = "accuracy",
-    target_scitype           = Vec{<:Finite},
-    prediction_type          = :deterministic,
-    orientation              = :score,
-    reports_each_observation = false,
-    is_feature_dependent     = false,
-    supports_weights         = true,
-    docstring                = "Classification accuracy; aliases: `accuracy`.")
+                 instances = ["accuracy",],
+                 target_scitype           = Vec{<:Finite},
+                 prediction_type          = :deterministic,
+                 orientation              = :score,
+                 reports_each_observation = false,
+                 is_feature_dependent     = false,
+                 supports_weights         = true),
 
+@create_aliases Accuracy
+
+@create_docs(Accuracy,
+body=
 """
-    accuracy
+Accuracy is proportion of correct predictions `ŷ[i]` that match the
+ground truth `y[i]` observations. $INVARIANT_LABEL
+""",
+scientific_type=DOC_FINITE)
 
-$(docstring(Accuracy()))
-
-    accuracy(ŷ, y)
-    accuracy(ŷ, y, w)
-    accuracy(conf_mat)
-
-Returns the accuracy of the (point) predictions `ŷ`,
-given true observations `y`, optionally weighted by the weights
-`w`. All three arguments must be abstract vectors of the same length.
-$INVARIANT_LABEL_MULTICLASS
-
-For more information, run `info(accuracy)`.
-
-"""
-const accuracy = Accuracy()
-
+# calling behaviour:
 (::Accuracy)(args...) = 1.0 - misclassification_rate(args...)
 (::Accuracy)(m::ConfusionMatrix) = sum(diag(m.mat)) / sum(m.mat)
-
 
 # -----------------------------------------------------------
 # balanced accuracy
@@ -292,38 +280,27 @@ const accuracy = Accuracy()
 struct BalancedAccuracy <: Measure end
 
 metadata_measure(BalancedAccuracy;
-    name                     = "balanced_accuracy",
-    target_scitype           = Vec{<:Finite},
-    prediction_type          = :deterministic,
-    orientation              = :score,
-    reports_each_observation = false,
-    is_feature_dependent     = false,
-    supports_weights         = true,
-    docstring                = "Balanced classification accuracy; aliases: "*
-                               "`balanced_accuracy`, `bacc`, `bac`.")
+                 instances = ["balanced_accuracy", "bacc", "bac"],
+                 target_scitype           = Vec{<:Finite},
+                 prediction_type          = :deterministic,
+                 orientation              = :score,
+                 reports_each_observation = false,
+                 is_feature_dependent     = false,
+                 supports_weights         = true)
 
-"""
-    balanced_accuracy
-
-$(docstring(BalancedAccuracy()))
-
-    balanced_accuracy(ŷ, y [, w])
-    balanced_accuracy(conf_mat)
-
-Return the balanced accuracy of the point prediction `ŷ`, given true
-observations `y`, optionally weighted by `w`. The balanced accuracy takes
-into consideration class imbalance.
-All  three arguments must have the same length.
-$INVARIANT_LABEL_MULTICLASS
-
-For more information, run `info(balanced_accuracy)`.
-
-"""
-const balanced_accuracy = BalancedAccuracy()
-const bacc = balanced_accuracy
-const bac  = bacc
 const BACC = BalancedAccuracy
+@create_aliases BACC
 
+@create_docs(BalancedAccuracy,
+body=
+"""
+Balanced accuracy compensates standard [`Accuracy`](@ref) for class imbalance.
+See [https://en.wikipedia.org/wiki/Precision_and_recall#Imbalanced_data](https://en.wikipedia.org/wiki/Precision_and_recall#Imbalanced_data).
+$INVARIANT_LABEL
+""",
+scientific_type=DOC_FINITE)
+
+# calling behavior:
 function (::BACC)(ŷ::Vec{<:CategoricalValue},
                   y::Vec{<:CategoricalValue})
     class_count = Dist.countmap(y)
@@ -343,7 +320,7 @@ function (::BACC)(ŷ::Vec{<:CategoricalValue},
 end
 
 # ==================================================================
-## BINARY AND ORDER-INDEPENDENT
+## DETERMINISTIC BINARY PREDICTIONS - ORDER-INDEPENDENT
 
 # ------------------------------------------------------------------
 # Matthew's correlation
@@ -351,35 +328,25 @@ end
 struct MatthewsCorrelation <: Measure end
 
 metadata_measure(MatthewsCorrelation;
-    name                     = "matthews_correlation",
-    target_scitype           = Vec{<:Finite{2}},
-    prediction_type          = :deterministic,
-    orientation              = :score,
-    reports_each_observation = false,
-    is_feature_dependent     = false,
-    supports_weights         = false,
-    docstring                = "Matthew's correlation; aliases: " *
-                               "`matthews_correlation`, `mcc`")
-
-"""
-    matthews_correlation
-
-$(docstring(MatthewsCorrelation()))
-
-    matthews_correlation(ŷ, y)
-    matthews_correlation(conf_mat)
-
-Return Matthews' correlation coefficient corresponding to the point
-prediction `ŷ`, given true observations `y`.
-$INVARIANT_LABEL_MULTICLASS
-
-For more information, run `info(matthews_correlation)`.
-
-"""
-const matthews_correlation = MatthewsCorrelation()
-const mcc = matthews_correlation
+                 instances = ["matthews_correlation", "mcc"],
+                 target_scitype           = Vec{<:Finite{2}},
+                 prediction_type          = :deterministic,
+                 orientation              = :score,
+                 reports_each_observation = false,
+                 is_feature_dependent     = false,
+                 supports_weights         = false)
 const MCC = MatthewsCorrelation
+@create_aliases MCC
 
+@create_docs(MatthewsCorrelation,
+body=
+"""
+[https://en.wikipedia.org/wiki/Matthews_correlation_coefficient](https://en.wikipedia.org/wiki/Matthews_correlation_coefficient)
+$INVARIANT_LABEL
+""",
+scientific_type=DOC_FINITE_BINARY)
+
+# calling behaviour:
 function (::MCC)(cm::ConfusionMatrix{C}) where C
     # http://rk.kvl.dk/introduction/index.html
     # NOTE: this is O(C^3), there may be a clever way to
@@ -409,40 +376,38 @@ end
              confmat(ŷ, y, warn=false) |> m
 
 # ---------------------------------------------------------
-# area under the ROC curve
+# AreaUnderCurve
 
-struct AUC <: Measure end
-
-metadata_measure(AUC;
-    name                     = "area_under_curve",
-    target_scitype           = Vec{<:Finite{2}},
-    prediction_type          = :probabilistic,
-    orientation              = :score,
-    reports_each_observation = false,
-    is_feature_dependent     = false,
-    supports_weights         = false,
-    docstring                = "Area under the ROC curve; "*
-       "aliases: `area_under_curve`, `auc`")
-
-"""
-    area_under_curve
-
-$(docstring(AUC()))
-
-    area_under_curve(ŷ, y)
-
-Return the area under the receiver operator characteristic (curve),
-for probabilistic predictions `ŷ`, given ground truth `y`.
-$INVARIANT_LABEL_BINARY
-
-For more information, run `info(area_under_curve)`.
-
-"""
-const area_under_curve = AUC()
-const auc = AUC()
-
-# implementation drawn from
+#. Implementation drawn from
 # https://www.ibm.com/developerworks/community/blogs/jfp/entry/Fast_Computation_of_AUC_ROC_score?lang=en
+# but this link is now broken. Author contacted here:
+# https://www.kaggle.com/c/microsoft-malware-prediction/discussion/76013.
+
+struct AreaUnderCurve <: Measure end
+
+metadata_measure(AreaUnderCurve;
+                 human_name = "area under the ROC",
+                 instances = ["area_under_curve", "auc"],
+                 target_scitype           = Vec{<:Finite{2}},
+                 prediction_type          = :probabilistic,
+                 orientation              = :score,
+                 reports_each_observation = false,
+                 is_feature_dependent     = false,
+                 supports_weights         = false)
+
+const AUC = AreaUnderCurve
+@create_aliases AreaUnderCurve
+
+@create_docs(AreaUnderCurve,
+body=
+"""
+Returns the area under the ROC ([receiver operator
+characteristic](https://en.wikipedia.org/wiki/Receiver_operating_characteristic))
+$INVARIANT_LABEL
+""",
+scitpye = DOC_FINITE_BINARY)
+
+# core algorithm:
 function _auc(::Type{P}, ŷ::Vec{<:UnivariateFinite},
               y::Vec) where P<:Real # type of probabilities
     lab_pos = classes(first(ŷ))[2] # 'positive' label
@@ -463,65 +428,79 @@ function _auc(::Type{P}, ŷ::Vec{<:UnivariateFinite},
     return auc / (n_neg * n_pos)
 end
 
-# ŷ inhomogeneous type:
+# calling behaviour:
 (::AUC)(ŷ::Vec{<:UnivariateFinite}, y::Vec) = _auc(Float64, ŷ, y)
 
-# ŷ homogeneous type (eg UnivariateFiniteVector case):
+# performant version for UnivariateFiniteVector:
 (::AUC)(ŷ::Vec{<:UnivariateFinite{S,V,R,P}}, y::Vec) where {S,V,R,P} =
     _auc(P, ŷ, y)
 
 
 # ==========================================================================
-## BINARY AND ORDER DEPENDENT
+# DETERMINISTIC BINARY PREDICTIONS - ORDER DEPENDENT
 
 const CM2 = ConfusionMatrix{2}
 
 # --------------------------------------------------------------------------
-# F_β-Score
+# FScore
 
-"""
-    FScore{β}(rev=nothing)
+struct FScore{T<:Real} <: Measure
+    β::T
+    rev::Union{Nothing,Bool}
+end
 
-One-parameter generalization, ``F_β``, of the F-measure or balanced F-score.
-
-[Wikipedia entry](https://en.wikipedia.org/wiki/F1_score)
-
-    FScore()(ŷ, y)
-
-Evaluate ``F_β`` score on observations,`ŷ`, given ground truth values, `y`.
-
-By default, the second element of `levels(y)` is designated as
-`true`. To reverse roles, use `FScore{β}(rev=true)` instead of
-`FScore{β}`.
-
-For more information, run `info(FScore)`.
-
-"""
-struct FScore{β} <: Measure rev::Union{Nothing,Bool} end
-
-FScore{β}(; rev=nothing) where β = FScore{β}(rev)
-FScore(; β=1.0, rev=nothing) = FScore{β}(rev)
+FScore(; β=1.0, rev=nothing) = FScore(β, rev)
 
 metadata_measure(FScore;
-    target_scitype           = Vec{<:Finite{2}},
-    prediction_type          = :deterministic,
-    orientation              = :score,
-    reports_each_observation = false,
-    is_feature_dependent     = false,
-    supports_weights         = false)
+                 human_name = "F-Score",
+                 instances = ["f1score",],
+                 target_scitype           = Vec{<:Finite{2}},
+                 prediction_type          = :deterministic,
+                 orientation              = :score,
+                 reports_each_observation = false,
+                 is_feature_dependent     = false,
+                 supports_weights         = false)
 
-MLJModelInterface.name(::Type{<:FScore{β}}) where β = "FScore{$β}"
-MLJModelInterface.name(::Type{FScore})            = "FScore" # for registry
-MLJModelInterface.docstring(::Type{<:FScore})       = "F_β score; aliases: " *
-                                        "`FScore{β}`, `f1score=FScore{1}`"
-const f1score      = FScore{1}()
+@create_aliases FScore
+
+@create_docs(FScore,
+body=
+"""
+This is the one-parameter generalization, ``F_β``, of the F-measure or
+balanced F-score.
+
+[https://en.wikipedia.org/wiki/F1_score](https://en.wikipedia.org/wiki/F1_score)
+
+Constructor signature: `FScore(; β=1.0, rev=true)`.
+
+By default, the second element of `levels(y)` is designated as
+`true`. To reverse roles, specify `rev=true`.
+""",
+scientific_type=DOC_ORDERED_FACTOR_BINARY,
+footer="Constructor signature: `FScore(β=1.0, rev=false)`. ")
+
+# calling on conf matrix:
+function (score::FScore)(m::CM2)
+    β = score.β
+    β2   = β^2
+    prec = precision(m)
+    rec  = recall(m)
+    return (1 + β2) * (prec * rec) / (β2 * prec + rec)
+end
+
+# calling on vectors:
+(m::FScore)(ŷ, y) = confmat(ŷ, y; rev=m.rev) |> m
 
 # -------------------------------------------------------------------------
-# truepositive, true_negative, etc
+# TruePositive and its cousins - struct and metadata declerations
 
-for M in (:TruePositive, :TrueNegative, :FalsePositive, :FalseNegative,
-          :TruePositiveRate, :TrueNegativeRate, :FalsePositiveRate,
-          :FalseNegativeRate, :FalseDiscoveryRate, :Precision, :NPV)
+const TRUE_POSITIVE_AND_COUSINS =
+    (:TruePositive, :TrueNegative, :FalsePositive, :FalseNegative,
+     :TruePositiveRate, :TrueNegativeRate, :FalsePositiveRate,
+     :FalseNegativeRate, :FalseDiscoveryRate, :Precision,
+     :NegativePredictiveValue)
+
+for M in TRUE_POSITIVE_AND_COUSINS
     ex = quote
         struct $M <: Measure rev::Union{Nothing,Bool} end
         $M(; rev=nothing) = $M(rev)
@@ -555,7 +534,8 @@ metadata_measure.((TruePositive, TrueNegative);
     is_feature_dependent     = false,
     supports_weights         = false)
 
-metadata_measure.((TruePositiveRate, TrueNegativeRate, Precision, NPV);
+metadata_measure.((TruePositiveRate, TrueNegativeRate, Precision,
+                   NegativePredictiveValue);
     target_scitype           = Vec{<:Finite{2}},
     prediction_type          = :deterministic,
     orientation              = :score,
@@ -563,315 +543,130 @@ metadata_measure.((TruePositiveRate, TrueNegativeRate, Precision, NPV);
     is_feature_dependent     = false,
     supports_weights         = false)
 
-# adjustments
-MMI.name(::Type{<:TruePositive})       = "true_positive"
-MMI.docstring(::Type{<:TruePositive})  = "Number of true positives; " *
-                                         "aliases: `true_positive`, `truepositive`."
-MMI.name(::Type{<:TrueNegative})       = "true_negative"
-MMI.docstring(::Type{<:TrueNegative})  = "Number of true negatives; " *
-                                         "aliases: `true_negative`, `truenegative`."
-MMI.name(::Type{<:FalsePositive})      = "false_positive"
-MMI.docstring(::Type{<:FalsePositive}) = "Number of false positives; " *
-                                         "aliases: `false_positive`, `falsepositive`."
-MMI.name(::Type{<:FalseNegative})      = "false_negative"
-MMI.docstring(::Type{<:FalseNegative}) = "Number of false negatives; " *
-                                         "aliases: `false_negative`, `falsenegative`."
+# adjustments:
+instances(::Type{<:TruePositive}) = ["true_positive", "truepositive"]
+human_name(::Type{<:TruePositive})  = "number of true positives"
 
-MMI.name(::Type{<:TruePositiveRate})      = "true_positive_rate"
-MMI.docstring(::Type{<:TruePositiveRate}) = "True positive rate; aliases: " *
-                               "`true_positive_rate`, `truepositive_rate`, `tpr`, `sensitivity`, " *
-                               "`recall`, `hit_rate`."
-MMI.name(::Type{<:TrueNegativeRate})      = "true_negative_rate"
-MMI.docstring(::Type{<:TrueNegativeRate}) = "true negative rate; aliases: " *
-                               "`true_negative_rate`, `truenegative_rate`, `tnr`, `specificity`, " *
-                               "`selectivity`."
-MMI.name(::Type{<:FalsePositiveRate})      = "false_positive_rate"
-MMI.docstring(::Type{<:FalsePositiveRate}) = "false positive rate; aliases: " *
-                               "`false_positive_rate`, `falsepositive_rate`, `fpr`, `fallout`."
-MMI.name(::Type{<:FalseNegativeRate})      = "false_negative_rate"
-MMI.docstring(::Type{<:FalseNegativeRate}) = "false negative rate; aliases: " *
-                               "`false_negative_rate`, `falsenegative_rate`, `fnr`, `miss_rate`."
-MMI.name(::Type{<:FalseDiscoveryRate})      = "false_discovery_rate"
-MMI.docstring(::Type{<:FalseDiscoveryRate}) = "false discovery rate; "*
-                               "aliases: `false_discovery_rate`, `falsediscovery_rate`, `fdr`."
-MMI.name(::Type{<:NPV})      = "negative_predictive_value"
-MMI.docstring(::Type{<:NPV}) = "negative predictive value; aliases: " *
-                               "`negative_predictive_value`, `negativepredictive_value`, `npv`."
+instances(::Type{<:TrueNegative}) = ["true_negative", "truenegative"]
+human_name(::Type{<:TrueNegative}) = "number of true negatives"
 
-MMI.name(::Type{<:Precision})         = "positive_predictive_value"
-MMI.docstring(::Type{<:Precision})    = "positive predictive value "*
-  "(aka precision); aliases: `positive_predictive_value`, `ppv`, `Precision()`, `positivepredictive_value`. "
+instances(::Type{<:FalsePositive}) = ["false_positive", "falsepositive"]
+human_name(::Type{<:FalsePositive}) = "number of false positives"
 
-"""
-    true_positive
+instances(::Type{<:FalseNegative}) = ["false_negative", "falsenegative"]
+human_name(::Type{<:FalseNegative}) = "number of false negatives"
 
-$(docstring(TruePositive()))
+instances(::Type{<:TruePositiveRate}) =
+    ["true_positive_rate", "truepositive_rate",
+     "tpr", "sensitivity", "recall", "hit_rate"]
+human_name(::Type{<:TruePositiveRate}) =
+    "true positive rate (a.k.a recall)"
 
-    true_positive(ŷ, y)
+instances(::Type{<:TrueNegativeRate}) =
+    ["true_negative_rate", "truenegative_rate", "tnr",
+     "specificity", "selectivity"]
 
-Number of true positives for observations `ŷ` and ground truth
-`y`. Assigns `false` to first element of `levels(y)`. To reverse roles,
-use `TruePositive(rev=true)` instead of `true_positive`.
+instances(::Type{<:FalsePositiveRate}) =
+    ["false_positive_rate", "falsepositive_rate",
+     "fpr", "fallout"]
+                               "."
+instances(::Type{<:FalseNegativeRate}) =
+    ["false_negative_rate", "falsenegative_rate", "fnr", "miss_rate"]
+                               "."
+instances(::Type{<:FalseDiscoveryRate}) =
+    ["false_discovery_rate", "falsediscovery_rate", "fdr"]
 
-For more information, run `info(true_positive)`.
+instances(::Type{<:NegativePredictiveValue}) =
+    ["negative_predictive_value", "negativepredictive_value", "npv"]
 
-"""
-const true_positive = TruePositive()
-const tp = TruePositive()
-const truepositive  = TruePositive()
-
-"""
-    true_negative
-
-$(docstring(TrueNegative()))
-
-    true_negative(ŷ, y)
-
-Number of true negatives for observations `ŷ` and ground truth
-`y`. Assigns `false` to first element of `levels(y)`. To reverse roles,
-use `TrueNegative(rev=true)` instead of `true_negative`.
+instances(::Type{<:Precision}) =
+    ["positive_predictive_value", "ppv", "positivepredictive_value", "precision"]
+human_name(::Type{<:Precision}) =
+    "precision (a.k.a. positive predictive value)"
 
 
-For more information, run `info(true_negative)`.
+# ---------------------------------------------------------------------
+# TruePositive and its cousins - doc-string building and alias creation
 
-"""
-const true_negative = TrueNegative()
-const tn = TrueNegative()
-const truenegative  = TrueNegative()
+for M in TRUE_POSITIVE_AND_COUSINS
+    eval(quote
+         $M == Precision || @create_aliases $M # precision handled separately
 
-"""
-    false_positive
+         @create_docs($M,
+         body=
+         """
+         Assigns `false` to first element of `levels(y)`. To reverse roles,
+         use `$(name($M))(rev=true)`.
+         """,
+         scientific_type=DOC_ORDERED_FACTOR_BINARY)
+         end)
+end
 
-$(docstring(FalsePositive()))
-
-    false_positive(ŷ, y)
-
-Number of false positives for observations `ŷ` and ground truth
-`y`. Assigns `false` to first element of `levels(y)`. To reverse roles,
-use `FalsePositive(rev=true)` instead of `false_positive`.
-
-
-For more information, run `info(false_positive)`.
-
-"""
-const false_positive = FalsePositive()
-const fp = FalsePositive()
-const falsepositive = FalsePositive()
-
-"""
-    false_negative
-
-$(docstring(FalseNegative()))
-
-    false_negative(ŷ, y)
-
-Number of false positives for observations `ŷ` and ground truth
-`y`. Assigns `false` to first element of `levels(y)`. To reverse roles,
-use `FalseNegative(rev=true)` instead of `false_negative`.
-
-For more information, run `info(false_negative)`.
-
-"""
-const false_negative = FalseNegative()
-const fn = FalseNegative()
-const falsenegative = FalseNegative()
-
-"""
-    true_positive_rate
-
-$(docstring(TruePositiveRate()))
-
-    true_positive_rate(ŷ, y)
-
-True positive rate for observations `ŷ` and ground truth `y`. Assigns
-`false` to first element of `levels(y)`. To reverse roles, use
-`TruePositiveRate(rev=true)` instead of `true_positive_rate`.
-
-For more information, run `info(true_positive_rate)`.
-
-"""
-const true_positive_rate = TruePositiveRate()
-const tpr = TruePositiveRate()
-const TPR = TruePositiveRate
-const truepositive_rate  = TPR()
-const recall = TPR()
-const Recall = TPR
-const sensitivity  = recall
-const hit_rate     = recall
-
-"""
-    true_negative_rate
-
-$(docstring(TrueNegativeRate()))
-
-    true_negative_rate(ŷ, y)
-
-True negative rate for observations `ŷ` and ground truth `y`. Assigns
-`false` to first element of `levels(y)`. To reverse roles, use
-`TrueNegativeRate(rev=true)` instead of `true_negative_rate`.
-
-For more information, run `info(true_negative_rate)`.
-
-"""
-const true_negative_rate = TrueNegativeRate()
-const tnr = TrueNegativeRate()
+# type aliases:
 const TNR = TrueNegativeRate
-const truenegative_rate  = TNR()
-const Specificity = TNR
-const specificity  = truenegative_rate
-const selectivity  = specificity
-
-"""
-    false_positive_rate
-
-$(docstring(FalsePositiveRate()))
-
-    false_positive_rate(ŷ, y)
-
-False positive rate for observations `ŷ` and ground truth `y`. Assigns
-`false` to first element of `levels(y)`. To reverse roles, use
-`FalsePositiveRate(rev=true)` instead of `false_positive_rate`.
-
-For more information, run `info(false_positive_rate)`.
-
-"""
-const false_positive_rate = FalsePositiveRate()
-const fpr = FalsePositiveRate()
+const Specificity = TrueNegativeRate
+const TPR = TruePositiveRate
+const Recall = TPR
 const FPR = FalsePositiveRate
-const falsepositive_rate = FPR()
-const fallout      = falsepositive_rate
-
-"""
-    false_negative_rate
-
-$(docstring(FalseNegativeRate()))
-
-    false_negative_rate(ŷ, y)
-
-False negative rate for observations `ŷ` and ground truth `y`. Assigns
-`false` to first element of `levels(y)`. To reverse roles, use
-`FalseNegativeRate(rev=true)` instead of `false_negative_rate`.
-
-For more information, run `info(false_negative_rate)`.
-
-"""
-const false_negative_rate = FalseNegativeRate()
-const fnr = FalseNegativeRate()
 const FNR = FalseNegativeRate
-const falsenegative_rate = FNR()
-const miss_rate    = falsenegative_rate
-
-"""
-    false_discovery_rate
-
-$(docstring(FalseDiscoveryRate()))
-
-    false_discovery_rate(ŷ, y)
-
-False discovery rate for observations `ŷ` and ground truth `y`. Assigns
-`false` to first element of `levels(y)`. To reverse roles, use
-`FalseDiscoveryRate(rev=true)` instead of `false_discovery_rate`.
-
-For more information, run `info(false_discovery_rate)`.
-
-"""
-const false_discovery_rate = FalseDiscoveryRate()
-const fdr = FalseDiscoveryRate()
 const FDR = FalseDiscoveryRate
-const falsediscovery_rate = FDR()
+const NPV = NegativePredictiveValue
+const PPV = Precision
 
-"""
-    negative_predictive_value
-
-$(docstring(NPV()))
-
-    negative_predictive_value(ŷ, y)
-
-Negative predictive value for observations `ŷ` and ground truth
-`y`. Assigns `false` to first element of `levels(y)`. To reverse roles,
-use `NPV(rev=true)` instead of `negative_predictive_value`.
-
-For more information, run `info(negative_predictive_value)`.
-
-"""
-const negative_predictive_value = NPV()
-const npv = NPV()
-const negativepredictive_value = NPV()
-
-"""
-    positive_predictive_value
-
-$(docstring(Precision()))
-
-    positive_predictive_value(ŷ, y)
-
-Positive predictive value for observations `ŷ` and ground truth
-`y`. Assigns `false` to first element of `levels(y)`. To reverse roles,
-use `Precision(rev=true)` instead of `positive_predictive_value`.
-
-For more information, run `info(positive_predictive_value)`.
-
-"""
+# special case of precision; cannot generate alias's automatically due
+# to conflict with Base.precision:
 const positive_predictive_value = Precision()
 const ppv = Precision()
 const positivepredictive_value = Precision()
-const PPV = Precision
 
-
-## INTERNAL FUNCTIONS ON CONFUSION MATRIX
+# ----------------------------------------------------------------------
+# TruePositive and its cousins - helper functions for confusion matrices
 
 _tp(m::CM2) = m[2,2]
 _tn(m::CM2) = m[1,1]
 _fp(m::CM2) = m[2,1]
 _fn(m::CM2) = m[1,2]
 
-_tpr(m::CM2) = tp(m) / (tp(m) + fn(m))
-_tnr(m::CM2) = tn(m) / (tn(m) + fp(m))
+_tpr(m::CM2) = _tp(m) / (_tp(m) + _fn(m))
+_tnr(m::CM2) = _tn(m) / (_tn(m) + _fp(m))
 _fpr(m::CM2) = 1 - _tnr(m)
 _fnr(m::CM2) = 1 - _tpr(m)
 
-_fdr(m::CM2) = fp(m) / (tp(m) + fp(m))
-_npv(m::CM2) = tn(m) / (tn(m) + fn(m))
+_fdr(m::CM2) = _fp(m) / (_tp(m) + _fp(m))
+_npv(m::CM2) = _tn(m) / (_tn(m) + _fn(m))
 
-## Callables on CM2
+# ----------------------------------------------------------------------
+# TruePositive and its cousins - calling behaviour
+
 # NOTE: here we assume the CM was constructed a priori with the
 # proper ordering so the field `rev` in the measure is ignored
 
+# on confusion matrices:
 (::TruePositive)(m::CM2)  = _tp(m)
 (::TrueNegative)(m::CM2)  = _tn(m)
 (::FalsePositive)(m::CM2) = _fp(m)
 (::FalseNegative)(m::CM2) = _fn(m)
-
 (::TPR)(m::CM2) = _tpr(m)
 (::TNR)(m::CM2) = _tnr(m)
 (::FPR)(m::CM2) = _fpr(m)
 (::FNR)(m::CM2) = _fnr(m)
-
 (::FDR)(m::CM2) = _fdr(m)
 (::NPV)(m::CM2) = _npv(m)
-
 (::Precision)(m::CM2) = 1.0 - _fdr(m)
 
-function (::FScore{β})(m::CM2) where β
-    β2   = β^2
-    prec = precision(m)
-    rec  = recall(m)
-    return (1 + β2) * (prec * rec) / (β2 * prec + rec)
-end
-
-## Callables on vectors
-
-for M in (TruePositive, TrueNegative, FalsePositive, FalseNegative,
-          TPR, TNR, FPR, FNR,
-          FDR, Precision, NPV, FScore)
+# on vectors (ŷ, y):
+for M_ex in TRUE_POSITIVE_AND_COUSINS
+    local M = eval(M_ex)
     (m::M)(ŷ, y) = confmat(ŷ, y; rev=m.rev) |> m
 end
 
-# specify this as `precision` is in Base and so is ambiguous
+# special `precision` case (conflict with Base.precision):
 Base.precision(m::CM2) = m |> Precision()
 Base.precision(ŷ, y)   = confmat(ŷ, y) |> Precision()
 
-## MULTICLASS AND ORDER INDEPENDENT
+
+# =================================================================
+#MULTICLASS AND ORDER INDEPENDENT
 
 const CM = ConfusionMatrix{N} where N
 
@@ -1416,7 +1211,7 @@ end
 end
 
 @inline function _mc_helper(m::CM, a::Vec{<:Real}, b::Vec{<:Real},
-                            average::MicroAvg, return_type) 
+                            average::MicroAvg, return_type)
     a_sum, b_sum = sum(a), sum(b)
     return a_sum / (a_sum + b_sum)
 end

--- a/src/measures/loss_functions_interface.jl
+++ b/src/measures/loss_functions_interface.jl
@@ -102,7 +102,7 @@ for M_ex in MARGIN_LOSSES
          @create_aliases $M_ex
          @create_docs($M_ex,
             body="See above for original LossFunctions.jl documentation. ",
-            scientific_type=DOC_FINITE_BINARY,
+            scitype=DOC_FINITE_BINARY,
             footer= sig)
          end)
 end

--- a/src/measures/loss_functions_interface.jl
+++ b/src/measures/loss_functions_interface.jl
@@ -1,5 +1,9 @@
 # implementation of MLJ measure interface for LossFunctions.jl
 
+naked(T::Type) = split(string(T), '.') |> last |> Symbol
+const MARGIN_LOSSES = naked.(subtypes(MarginLoss))
+const DISTANCE_LOSSES = naked.(subtypes(DistanceLoss))
+
 # Supervised Loss -- measure traits
 const LSF = LossFunctions
 is_measure_type(::Type{<:SupervisedLoss})          = true
@@ -8,13 +12,14 @@ reports_each_observation(::Type{<:SupervisedLoss}) = true
 is_feature_dependent(::Type{<:SupervisedLoss})     = false
 
 MMI.supports_weights(::Type{<:SupervisedLoss}) = true
-MMI.name(M::Type{<:SupervisedLoss})            = split(string(M), '.')[end]*"()"
 MMI.docstring(M::Type{<:SupervisedLoss})       = name(M)
+instances(M::Type{<:SupervisedLoss}) = [snakecase(string.(naked(M))), ]
+
 
 ## DISTANCE BASED LOSS FUNCTION
 
 MMI.prediction_type(::Type{<:DistanceLoss}) = :deterministic
-MMI.target_scitype(::Type{<:DistanceLoss})  = AbstractArray{<:Continuous}
+MMI.target_scitype(::Type{<:DistanceLoss}) = Union{Vec{Continuous},Vec{Count}}
 
 function value(measure::DistanceLoss, yhat, X, y, ::Nothing,
                 ::Val{false}, ::Val{true})
@@ -26,12 +31,13 @@ function value(measure::DistanceLoss, yhat, X, y, w,
     return w .* value(measure, yhat, X, y, nothing) ./ (sum(w)/length(y))
 end
 
+
 ## MARGIN BASED LOSS FUNCTIONS
 
 MMI.prediction_type(::Type{<:MarginLoss}) = :probabilistic
-MMI.target_scitype(::Type{<:MarginLoss})  = AbstractArray{<:Binary}
+MMI.target_scitype(::Type{<:MarginLoss})  = AbstractArray{<:Finite{2}}
 
-# rescale [0, 1] -> [-1, 1]
+# rescale [0, 1] -> [-1, 1]:
 _scale(p) = 2p - 1
 
 function value(measure::MarginLoss, yhat, X, y, ::Nothing,
@@ -44,4 +50,66 @@ end
 function value(measure::MarginLoss, yhat, X, y, w,
                 ::Val{false}, ::Val{true})
     return w .* value(measure, yhat, X, y, nothing) ./ (sum(w)/length(y))
+end
+
+
+## KEYWORD CONSTRUCTORS
+
+# distance:
+DWDMarginLoss(; q=1.0)         = LossFunctions.DWDMarginLoss(q)
+SmoothedL1HingeLoss(; γ=1.0) = LossFunctions.SmoothedL1HingeLoss(γ)
+
+# margin:
+HuberLoss(x...; d=1.0)        = LossFunctions.HuberLoss(d)
+L1EpsilonInsLoss(; ϵ=1.0) = LossFunctions.L1EpsilonInsLoss(ϵ)
+L2EpsilonInsLoss(; ϵ=1.0) = LossFunctions.L2EpsilonInsLoss(ϵ)
+LPDistLoss(; P=2)         = LossFunctions.LPDistLoss(P)
+QuantileLoss(; τ=0.7)     = LossFunctions.QuantileLoss(τ)
+
+
+## ADJUSTMENTS
+
+human_name(::Type{<:L1EpsilonInsLoss}) = "l1 ϵ-insensitive loss"
+human_name(::Type{<:L2EpsilonInsLoss}) = "l2 ϵ-insensitive loss"
+human_name(::Type{<:DWDMarginLoss}) = "distance weighted discrimination loss"
+
+_signature(::Any) = ""
+_signature(::Type{<:DWDMarginLoss}) = "`DWDMarginLoss(; q=1.0)`"
+_signature(::Type{<:SmoothedL1HingeLoss}) = "`SmoothedL1HingeLoss(; γ=1.0)`"
+_signature(::Type{<:L1EpsilonInsLoss}) = "`L1EpsilonInsLoss(; ϵ=1.0)`"
+_signature(::Type{<:L2EpsilonInsLoss}) = "`L2EpsilonInsLoss(; ϵ=1.0)`"
+_signature(::Type{<:LPDistLoss}) = "`LPDistLoss(; P=2)`"
+_signature(::Type{<:QuantileLoss}) = "`QuantileLoss(; τ=0.7)`"
+
+
+## ALIASES AND DOCSTRINGS
+
+for M_ex in DISTANCE_LOSSES
+    eval(quote
+         sig = _signature($M_ex)
+         isempty(sig) || (sig = "Constructor signature: "*sig)
+         @create_aliases $M_ex
+         @create_docs($M_ex,
+            body="See above for original LossFunctions.jl documentation. ",
+            footer=sig)
+         end)
+end
+
+for M_ex in MARGIN_LOSSES
+    eval(quote
+         sig = _signature($M_ex)
+         isempty(sig) || (sig = "Constructor signature: "*sig)
+         @create_aliases $M_ex
+         @create_docs($M_ex,
+            body="See above for original LossFunctions.jl documentation. ",
+            scientific_type=DOC_FINITE_BINARY,
+            footer= sig)
+         end)
+end
+
+## CALLING BEHAVIOUR
+
+for M in vcat(subtypes(DistanceLoss), subtypes(MarginLoss))
+    (m::M)(yhat, y) = MLJBase.value(m, yhat, nothing, y, nothing)
+    (m::M)(yhat, y, w) = MLJBase.value(m, yhat, nothing, y, w)
 end

--- a/src/measures/measure_search.jl
+++ b/src/measures/measure_search.jl
@@ -6,8 +6,6 @@ const LOSSFUNCTIONS_MEASURE_TYPES =
 
 const MEASURE_TYPES = vcat(LOCAL_MEASURE_TYPES, LOSSFUNCTIONS_MEASURE_TYPES)
 
-push!(MEASURE_TYPES, Confusion)
-
 const MeasureProxy = NamedTuple{Tuple(MEASURE_TRAITS)}
 
 function Base.show(stream::IO, p::MeasureProxy)

--- a/src/measures/measure_search.jl
+++ b/src/measures/measure_search.jl
@@ -1,14 +1,4 @@
-# *Important:* If there is a measure trait that depends on the value
-# of a type parameter (eg, `target_scitype(Brier_Score{D})` depends on
-# the value of `D`) then we need a separate listing below for each
-# case. Otherwise, the UnionAll type suffices. So, for example,
-# although `FScore{β}` has a type parameter `β`, no trait depends on the
-# value of `β`, so we need only an entry for `FScore`
-
-
 const LOCAL_MEASURE_TYPES = subtypes(MLJBase.Measure)
-filter!(M -> M != BrierScore, LOCAL_MEASURE_TYPES)
-push!(LOCAL_MEASURE_TYPES, BrierScore{UnivariateFinite})
 
 const LOSSFUNCTIONS_MEASURE_TYPES =
     vcat(subtypes(LossFunctions.MarginLoss),
@@ -20,8 +10,10 @@ push!(MEASURE_TYPES, Confusion)
 
 const MeasureProxy = NamedTuple{Tuple(MEASURE_TRAITS)}
 
-Base.show(stream::IO, p::MeasureProxy) =
-    print(stream, "(name = $(p.name), instances= $(p.instances), ...)")
+function Base.show(stream::IO, p::MeasureProxy)
+    instances = "["*join(p.instances, ", ")*"]"
+    print(stream, "(name = $(p.name), instances = $instances, ...)")
+end
 
 function Base.show(stream::IO, ::MIME"text/plain", p::MeasureProxy)
     printstyled(IOContext(stream, :color=> MLJBase.SHOW_COLOR),

--- a/src/measures/measure_search.jl
+++ b/src/measures/measure_search.jl
@@ -21,7 +21,7 @@ push!(MEASURE_TYPES, Confusion)
 const MeasureProxy = NamedTuple{Tuple(MEASURE_TRAITS)}
 
 Base.show(stream::IO, p::MeasureProxy) =
-    print(stream, "(name = $(p.name), ...)")
+    print(stream, "(name = $(p.name), instances= $(p.instances), ...)")
 
 function Base.show(stream::IO, ::MIME"text/plain", p::MeasureProxy)
     printstyled(IOContext(stream, :color=> MLJBase.SHOW_COLOR),

--- a/src/measures/measures.jl
+++ b/src/measures/measures.jl
@@ -9,7 +9,8 @@ const MEASURE_TRAITS =
      :distribution_type, :supports_class_weights]
 
 # already defined in model_traits.jl:
-# name              - fallback for non-MLJType is string(M) where M is arg
+# name              - fallback for non-MLJType is string(coretype(M))
+#                                                      where M is arg
 # target_scitype    - fallback value = Unknown
 # supports_weights  - fallback value = false
 # prediction_type   - fallback value = :unknown (also: :deterministic,
@@ -21,8 +22,8 @@ orientation(::Type) = :loss  # other options are :score, :other
 reports_each_observation(::Type) = false
 aggregation(::Type) = Mean()  # other option is Sum() or callable object
 is_feature_dependent(::Type) = false
-instances(::Type) = String[]
 human_name(::Type) = snakecase(name(M), delim=' ')
+instances(::Type) = String[]
 
 # specific to `Finite` measures:
 supports_class_weights(::Type) = false
@@ -32,7 +33,7 @@ distribution_type(::Type) = missing
 
 # extend to instances:
 for trait in [:orientation, :reports_each_observation, :aggregation,
-              :is_feature_dependent, :instances, :supports_class_weights,
+              :is_feature_dependent, :supports_class_weights,
               :distribution_type]
     eval(:($trait(m) = $trait(typeof(m))))
 end

--- a/src/measures/measures.jl
+++ b/src/measures/measures.jl
@@ -1,3 +1,14 @@
+const DOC_FINITE =
+    "`AbstractArray{<:Finite}` (multiclass classification)"
+const DOC_FINITE_BINARY =
+    "`AbstractArray{<:Finite{2}}` (binary classification)"
+const DOC_ORDERED_FACTOR =
+    "`AbstractArray{<:OrderedFactor}` (classification of ordered target)"
+const DOC_ORDERED_FACTOR_BINARY =
+    "`AbstractArray{<:OrderedFactor{2}}` "*
+    "(binary classification where choice of \"true\" effects the measure)"
+const DOC_CONTINUOUS = "`AbstractArray{Continuous}` (regression)"
+
 ## TRAITS
 
 is_measure_type(::Any) = false

--- a/src/measures/meta_utilities.jl
+++ b/src/measures/meta_utilities.jl
@@ -17,12 +17,12 @@ macro create_aliases(M_ex)
         end)
 end
 
-function detailed_doc_string(M; body="", footer="", scientific_type="")
+function detailed_doc_string(M; body="", footer="", scitype="")
 
     _instances = _decorate(instances(M))
     human_name = MLJBase.human_name(M)
-    if isempty(scientific_type)
-        scientific_type = target_scitype(M) |> string
+    if isempty(scitype)
+        scitype = target_scitype(M) |> string
     end
 
     ret =  "    $M\n\n"
@@ -49,7 +49,7 @@ function detailed_doc_string(M; body="", footer="", scientific_type="")
         (ret *= DOC_CLASS_WEIGHTS)
     ret *= "\n\n"
     isempty(body) || (ret *= "$body\n\n")
-    ret *= "Requires `scitype(y)` to be a subtype of $scientific_type; "
+    ret *= "Requires `scitype(y)` to be a subtype of $scitype; "
     ret *= "`ŷ` must be a $(prediction_type(M)) prediction. "
     isempty(footer) ||(ret *= "\n\n$footer")
     ret *= "\n\n"
@@ -60,7 +60,7 @@ end
 
 _err_create_docs() = error(
     "@create_docs syntax error. Usage: \n"*
-    "@create_docs(MeasureType, body=..., scientific_type=..., footer=...")
+    "@create_docs(MeasureType, body=..., scitype=..., footer=...")
 macro create_docs(M_ex, exs...)
     M_ex isa Symbol || _err_create_docs()
     b = ""
@@ -69,11 +69,11 @@ macro create_docs(M_ex, exs...)
     for ex in exs
         ex.head == :(=) || _err_create_docs()
         ex.args[1] == :body &&            (b = ex.args[2])
-        ex.args[1] == :scientific_type && (s = ex.args[2])
+        ex.args[1] == :scitype && (s = ex.args[2])
         ex.args[1] == :footer &&          (f = ex.args[2])
     end
     esc(quote
-        "$(detailed_doc_string($M_ex, body=$b, scientific_type=$s, footer=$f))"
+        "$(detailed_doc_string($M_ex, body=$b, scitype=$s, footer=$f))"
         function $M_ex end
         end)
 end

--- a/src/measures/meta_utilities.jl
+++ b/src/measures/meta_utilities.jl
@@ -51,8 +51,8 @@ function detailed_doc_string(M; body="", footer="", scientific_type="")
     isempty(body) || (ret *= "$body\n\n")
     ret *= "Requires `scitype(y)` to be a subtype of $scientific_type; "
     ret *= "`ŷ` must be a $(prediction_type(M)) prediction. "
-    ret *= "\n\n"
     isempty(footer) ||(ret *= "\n\n$footer")
+    ret *= "\n\n"
     ret *= "For more information, run `info($(name(M)))`. "
     return ret
 end

--- a/src/measures/meta_utilities.jl
+++ b/src/measures/meta_utilities.jl
@@ -100,7 +100,7 @@ function metadata_measure(T; name::String="",
                           distribution_type=missing)
     pred_str        = "$prediction_type"
     orientation_str = "$orientation"
-    dist = ifelse(ismissing(distribution_type), missing, "$distribution_type")
+#    dist = ifelse(ismissing(distribution_type), missing, "$distribution_type")
     ex = quote
 
         # traits common with models:
@@ -126,7 +126,7 @@ function metadata_measure(T; name::String="",
         aggregation(::Type{<:$T}) = $aggregation
         is_feature_dependent(::Type{<:$T}) = $is_feature_dependent
         supports_class_weights(::Type{<:$T}) = $supports_class_weights
-        distribution_type(::Type{<:$T}) = $dist
+        distribution_type(::Type{<:$T}) = $distribution_type
 
     end
     parentmodule(T).eval(ex)

--- a/src/measures/meta_utilities.jl
+++ b/src/measures/meta_utilities.jl
@@ -1,0 +1,98 @@
+const DOC_OBSERVATIONS =
+    "on observations `ŷ`, "*
+    "given ground truth values, `y`. "
+const DOC_WEIGHTS =
+    "Optionally specify per-sample weights, `w`. "
+const DOC_CLASS_WEIGHTS =
+    "An optional `AbstractDict`, denoted `class_w` above, "*
+    "keyed on `levels(y)`, specifies class weights. "
+
+macro create_aliases(ex)
+    esc(quote
+        M = $ex
+        for alias in Symbol.(instances($ex))
+            eval(:(const $alias = $M()))
+        end
+        end)
+end
+
+function detailed_doc_string(M; leader= "", body="", footer="")
+    _instances = _decorate(instances(M))
+    if isempty(leader)
+        if isempty(fieldnames(M))
+            leader = "Evaluate the $(informal_name(M)) "
+        else
+            leader = "Evaluate the default instance of the measure "
+        end
+        leader *= "$DOC_OBSERVATIONS"
+    end
+    ret =  "    $M\n\n"
+    ret *= "A measure type"
+    isempty(_instances) ||
+        (ret  *= ", which includes the instance(s) $_instances")
+    ret *= ".\n\n"
+    ret *= "    $(name(M))()(ŷ, y)\n"
+    supports_weights(M) &&
+        (ret *= "    $(name(M))()(ŷ, y, w)\n")
+    supports_class_weights(M) &&
+        (ret *= "    $(name(M))()(ŷ, y, class_w)\n")
+    ret *= "\n$leader"
+    supports_weights(M) &&
+        (ret *= DOC_WEIGHTS)
+    supports_class_weights(M) &&
+        (ret *= DOC_CLASS_WEIGHTS)
+    ret *= "\n\n"
+    isempty(body) || (ret *= "$body\n\n")
+    ret *= "For more information, run `info($(name(M)))`. "
+    isempty(footer) ||
+        (ret *= "\n\n$footer")
+    return ret
+end
+
+
+# TODO: I wonder why this is not a macro?
+
+"""
+    metadata_measure(T; kw...)
+
+Helper function to write the metadata for a single measure.
+"""
+function metadata_measure(T; name::String="",
+                          instances::Vector{String}=String[],
+                          target_scitype=Unknown,
+                          prediction_type::Symbol=:unknown,
+                          orientation::Symbol=:unknown,
+                          reports_each_observation::Bool=true,
+                          aggregation=Mean(),
+                          is_feature_dependent::Bool=false,
+                          supports_weights::Bool=false,
+                          supports_class_weights::Bool=false,
+                          docstring::String="",
+                          distribution_type=missing)
+    pred_str        = "$prediction_type"
+    orientation_str = "$orientation"
+    dist = ifelse(ismissing(distribution_type), missing, "$distribution_type")
+    ex = quote
+        if !isempty($name)
+            MMI.name(::Type{<:$T}) = $name
+        end
+        if !isempty($instances)
+            instances(::Type{<:$T}) = $instances
+        end
+        if !isempty($docstring)
+            MMI.docstring(::Type{<:$T}) = $docstring
+        end
+        # traits common with models
+        MMI.target_scitype(::Type{<:$T}) = $target_scitype
+        MMI.prediction_type(::Type{<:$T}) = Symbol($pred_str)
+        MMI.supports_weights(::Type{<:$T}) = $supports_weights
+        # traits specific to measures
+        orientation(::Type{<:$T}) = Symbol($orientation_str)
+        reports_each_observation(::Type{<:$T}) = $reports_each_observation
+        aggregation(::Type{<:$T}) = $aggregation
+        is_feature_dependent(::Type{<:$T}) = $is_feature_dependent
+        supports_class_weights(::Type{<:$T}) = $supports_class_weights
+        distribution_type(::Type{<:$T}) = $dist
+    end
+    parentmodule(T).eval(ex)
+end

--- a/src/measures/meta_utilities.jl
+++ b/src/measures/meta_utilities.jl
@@ -1,54 +1,82 @@
 const DOC_OBSERVATIONS =
     "on observations `ŷ`, "*
-    "given ground truth values, `y`. "
+    "given ground truth values `y`. "
 const DOC_WEIGHTS =
     "Optionally specify per-sample weights, `w`. "
 const DOC_CLASS_WEIGHTS =
     "An optional `AbstractDict`, denoted `class_w` above, "*
     "keyed on `levels(y)`, specifies class weights. "
 
-macro create_aliases(ex)
+macro create_aliases(M_ex)
     esc(quote
-        M = $ex
-        for alias in Symbol.(instances($ex))
-            eval(:(const $alias = $M()))
+        M = $M_ex
+        for alias in Symbol.(instances(M))
+        # isdefined(parentmodule(M), alias) || eval(:(const $alias = $M()))
+        eval(:(const $alias = $M()))
         end
         end)
 end
 
-function detailed_doc_string(M; leader= "", body="", footer="")
+function detailed_doc_string(M; body="", footer="", scientific_type="")
+
     _instances = _decorate(instances(M))
-    if isempty(leader)
-        if isempty(fieldnames(M))
-            leader = "Evaluate the $(informal_name(M)) "
-        else
-            leader = "Evaluate the default instance of the measure "
-        end
-        leader *= "$DOC_OBSERVATIONS"
+    human_name = MLJBase.human_name(M)
+    if isempty(scientific_type)
+        scientific_type = target_scitype(M) |> string
     end
+
     ret =  "    $M\n\n"
-    ret *= "A measure type"
+    ret *= "A measure type for $(human_name)"
     isempty(_instances) ||
-        (ret  *= ", which includes the instance(s) $_instances")
+        (ret  *= ", which includes the instance(s), "*
+         "$_instances")
     ret *= ".\n\n"
     ret *= "    $(name(M))()(ŷ, y)\n"
     supports_weights(M) &&
         (ret *= "    $(name(M))()(ŷ, y, w)\n")
     supports_class_weights(M) &&
         (ret *= "    $(name(M))()(ŷ, y, class_w)\n")
-    ret *= "\n$leader"
+    ret *= "\n"
+    if isempty(fieldnames(M))
+            ret *= "Evaluate the $(human_name) "
+    else
+        ret *= "Evaluate the default instance of $(name(M)) "
+    end
+    ret *= "$DOC_OBSERVATIONS"
     supports_weights(M) &&
         (ret *= DOC_WEIGHTS)
     supports_class_weights(M) &&
         (ret *= DOC_CLASS_WEIGHTS)
     ret *= "\n\n"
     isempty(body) || (ret *= "$body\n\n")
+    ret *= "Requires `scitype(y)` to be a subtype of $scientific_type; "
+    ret *= "`ŷ` must be a $(prediction_type(M)) prediction. "
+    ret *= "\n\n"
+    isempty(footer) ||(ret *= "\n\n$footer")
     ret *= "For more information, run `info($(name(M)))`. "
-    isempty(footer) ||
-        (ret *= "\n\n$footer")
     return ret
 end
 
+
+_err_create_docs() = error(
+    "@create_docs syntax error. Usage: \n"*
+    "@create_docs(MeasureType, body=..., scientific_type=..., footer=...")
+macro create_docs(M_ex, exs...)
+    M_ex isa Symbol || _err_create_docs()
+    b = ""
+    s = ""
+    f = ""
+    for ex in exs
+        ex.head == :(=) || _err_create_docs()
+        ex.args[1] == :body &&            (b = ex.args[2])
+        ex.args[1] == :scientific_type && (s = ex.args[2])
+        ex.args[1] == :footer &&          (f = ex.args[2])
+    end
+    esc(quote
+        "$(detailed_doc_string($M_ex, body=$b, scientific_type=$s, footer=$f))"
+        function $M_ex end
+        end)
+end
 
 # TODO: I wonder why this is not a macro?
 
@@ -58,6 +86,7 @@ end
 Helper function to write the metadata for a single measure.
 """
 function metadata_measure(T; name::String="",
+                          human_name="",
                           instances::Vector{String}=String[],
                           target_scitype=Unknown,
                           prediction_type::Symbol=:unknown,
@@ -73,26 +102,32 @@ function metadata_measure(T; name::String="",
     orientation_str = "$orientation"
     dist = ifelse(ismissing(distribution_type), missing, "$distribution_type")
     ex = quote
+
+        # traits common with models:
         if !isempty($name)
             MMI.name(::Type{<:$T}) = $name
-        end
-        if !isempty($instances)
-            instances(::Type{<:$T}) = $instances
         end
         if !isempty($docstring)
             MMI.docstring(::Type{<:$T}) = $docstring
         end
-        # traits common with models
         MMI.target_scitype(::Type{<:$T}) = $target_scitype
         MMI.prediction_type(::Type{<:$T}) = Symbol($pred_str)
         MMI.supports_weights(::Type{<:$T}) = $supports_weights
-        # traits specific to measures
+
+        # traits specific to measures:
+        if !isempty($instances)
+            instances(::Type{<:$T}) = $instances
+        end
+        if !isempty($human_name)
+            human_name(::Type{<:$T}) = $human_name
+        end
         orientation(::Type{<:$T}) = Symbol($orientation_str)
         reports_each_observation(::Type{<:$T}) = $reports_each_observation
         aggregation(::Type{<:$T}) = $aggregation
         is_feature_dependent(::Type{<:$T}) = $is_feature_dependent
         supports_class_weights(::Type{<:$T}) = $supports_class_weights
         distribution_type(::Type{<:$T}) = $dist
+
     end
     parentmodule(T).eval(ex)
 end

--- a/test/info_dict.jl
+++ b/test/info_dict.jl
@@ -179,8 +179,7 @@ end
 end
 
 @testset "info for measures" begin
-    @test info(rms).name == "rms"
-    info(L2DistLoss()).name == "LPDistLoss{2}"
+    @test info(rms).name == "RootMeanSquaredError"
 end
 
 end

--- a/test/measures/confusion_matrix.jl
+++ b/test/measures/confusion_matrix.jl
@@ -7,36 +7,37 @@ using .Models
     y = categorical(['m', 'f', 'n', 'f', 'm', 'n', 'n', 'm', 'f'])
     ŷ = categorical(['f', 'f', 'm', 'f', 'n', 'm', 'n', 'm', 'f'])
     l = levels(y) # f, m, n
-    cm = confmat(ŷ, y; warn=false)
+    cm = MLJBase._confmat(ŷ, y; warn=false)
     e(l,i,j) = sum((ŷ .== l[i]) .& (y .== l[j]))
     for i in 1:3, j in 1:3
         @test cm[i,j] == e(l,i,j)
     end
     perm = [3, 1, 2]
     l2 = l[perm]
-    cm2 = confmat(ŷ, y; perm=perm) # no warning because permutation is given
+    cm2 = MLJBase._confmat(ŷ, y; perm=perm) # no warning because permutation is given
+    m = ConfusionMatrix(perm=perm)
     for i in 1:3, j in 1:3
         @test cm2[i,j] == e(l2,i,j)
     end
-    @test_logs (:warn, "The classes are un-ordered,\nusing order: ['f', 'm', 'n'].\nTo suppress this warning, consider coercing to OrderedFactor.") confmat(ŷ, y)
+    @test_logs (:warn, "The classes are un-ordered,\nusing order: ['f', 'm', 'n'].\nTo suppress this warning, consider coercing to OrderedFactor.") MLJBase._confmat(ŷ, y)
     ŷc = coerce(ŷ, OrderedFactor)
     yc = coerce(y, OrderedFactor)
-    @test confmat(ŷc, yc).mat == cm.mat
+    @test MLJBase._confmat(ŷc, yc).mat == cm.mat
 
     y = categorical(['a','b','a','b'])
     ŷ = categorical(['b','b','a','a'])
-    @test_logs (:warn, "The classes are un-ordered,\nusing: negative='a' and positive='b'.\nTo suppress this warning, consider coercing to OrderedFactor.") confmat(ŷ, y)
+    @test_logs (:warn, "The classes are un-ordered,\nusing: negative='a' and positive='b'.\nTo suppress this warning, consider coercing to OrderedFactor.") MLJBase._confmat(ŷ, y)
 
     # more tests for coverage
     y = categorical([1,2,3,1,2,3,1,2,3])
     ŷ = categorical([1,2,3,1,2,3,1,2,3])
-    @test_throws ArgumentError confmat(ŷ, y, rev=true)
+    @test_throws ArgumentError MLJBase._confmat(ŷ, y, rev=true)
 
     # silly test for display
     ŷ = coerce(y, OrderedFactor)
     y = coerce(y, OrderedFactor)
     iob = IOBuffer()
-    Base.show(iob, MIME("text/plain"), confmat(ŷ, y))
+    Base.show(iob, MIME("text/plain"), MLJBase._confmat(ŷ, y))
     siob = String(take!(iob))
     @test strip(siob) == strip("""
                          ┌─────────────────────────────────────────┐
@@ -50,10 +51,9 @@ using .Models
            ├─────────────┼─────────────┼─────────────┼─────────────┤
            │      3      │      0      │      0      │      3      │
            └─────────────┴─────────────┴─────────────┴─────────────┘""")
-
 end
 
-@testset "confmat as measure" begin
+@testset "ConfusionMatrix measure" begin
 
     @test info(confmat).orientation == :other
     model = DeterministicConstantClassifier()
@@ -63,7 +63,9 @@ end
     y = long[1:10]
     yhat =long[11:20]
 
-    confmat(yhat, y).mat == [1 2 0; 3 1 1; 1 1 0]
+    @test confmat(yhat, y).mat == [1 2 0; 3 1 1; 1 1 0]
+    @test ConfusionMatrix(perm=[2, 1, 3])(yhat, y).mat ==
+        MLJBase._confmat(yhat, y, perm=[2, 1, 3]).mat
 
     MLJBase.value(confmat, yhat, X, y, nothing)
 

--- a/test/measures/continuous.jl
+++ b/test/measures/continuous.jl
@@ -23,7 +23,6 @@ rng = StableRNG(666899)
     @test isapprox(mape(yhat, y), (1/1 + 1/2 + 1/3 + 1/4)/4)
 end
 
-
 @testset "MLJBase.value" begin
     yhat = randn(rng,5)
     X = (weight=randn(rng,5), x1 = randn(rng,5))

--- a/test/measures/finite.jl
+++ b/test/measures/finite.jl
@@ -51,7 +51,7 @@ end
     y = categorical(['m', 'f', 'n', 'f', 'm', 'n', 'n', 'm', 'f'])
     ŷ = categorical(['f', 'f', 'm', 'f', 'n', 'm', 'n', 'm', 'f'])
     @test accuracy(ŷ, y) == 1-mcr(ŷ,y) ==
-            accuracy(_confmat(ŷ, y, warn=false))  == 1-mcr(_confmat(ŷ, y, warn=false))
+            accuracy(MLJBase._confmat(ŷ, y, warn=false))  == 1-mcr(MLJBase._confmat(ŷ, y, warn=false))
     w = randn(rng,length(y))
     @test accuracy(ŷ, y, w) == 1-mcr(ŷ,y,w)
 
@@ -82,7 +82,7 @@ end
     sk_mcc = -0.09759509982785947
     @test mcc(ŷ, y) == matthews_correlation(ŷ, y) ≈ sk_mcc
     # invariance with respect to permutation ?
-    cm = _confmat(ŷ, y, perm=[3, 1, 2, 4])
+    cm = MLJBase._confmat(ŷ, y, perm=[3, 1, 2, 4])
     @test mcc(cm) ≈ sk_mcc
 end
 
@@ -140,7 +140,7 @@ end
     # first class is 1 is assumed negative, second positive
     y = categorical([1, 2, 1, 2, 1, 1, 2])
     ŷ = categorical([1, 2, 2, 2, 2, 1, 2])
-    cm = _confmat(ŷ, y, warn=false)
+    cm = MLJBase._confmat(ŷ, y, warn=false)
     TN = sum(ŷ .== y .== 1) # pred and true = - (1)
     TP = sum(ŷ .== y .== 2) # pred and true = + (2)
     FP = sum(ŷ .!= y .== 1) # pred + (2) and true - (1)
@@ -150,7 +150,7 @@ end
     @test cm[1,2] == FN
     @test cm[2,1] == FP
 
-    cm2 = _confmat(ŷ, y; rev=true)
+    cm2 = MLJBase._confmat(ŷ, y; rev=true)
     @test cm2[1,1] == cm[2,2]
     @test cm2[1,2] == cm[2,1]
     @test cm2[2,2] == cm[1,1]
@@ -185,7 +185,7 @@ end
     y = coerce([0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2], Multiclass)
     ŷ = coerce([0, 1, 0, 0, 0, 2, 1, 2, 0, 1, 1, 2], Multiclass)
     class_w = Dict(0=>0,2=>2,1=>1)
-    cm = _confmat(ŷ, y, warn=false)
+    cm = MLJBase._confmat(ŷ, y, warn=false)
 
     #               ┌─────────────────────────────────────────┐
     #               │              Ground Truth               │

--- a/test/measures/finite.jl
+++ b/test/measures/finite.jl
@@ -51,7 +51,7 @@ end
     y = categorical(['m', 'f', 'n', 'f', 'm', 'n', 'n', 'm', 'f'])
     ŷ = categorical(['f', 'f', 'm', 'f', 'n', 'm', 'n', 'm', 'f'])
     @test accuracy(ŷ, y) == 1-mcr(ŷ,y) ==
-            accuracy(confmat(ŷ, y, warn=false))  == 1-mcr(confmat(ŷ, y, warn=false))
+            accuracy(_confmat(ŷ, y, warn=false))  == 1-mcr(_confmat(ŷ, y, warn=false))
     w = randn(rng,length(y))
     @test accuracy(ŷ, y, w) == 1-mcr(ŷ,y,w)
 
@@ -82,7 +82,7 @@ end
     sk_mcc = -0.09759509982785947
     @test mcc(ŷ, y) == matthews_correlation(ŷ, y) ≈ sk_mcc
     # invariance with respect to permutation ?
-    cm = confmat(ŷ, y, perm=[3, 1, 2, 4])
+    cm = _confmat(ŷ, y, perm=[3, 1, 2, 4])
     @test mcc(cm) ≈ sk_mcc
 end
 
@@ -140,7 +140,7 @@ end
     # first class is 1 is assumed negative, second positive
     y = categorical([1, 2, 1, 2, 1, 1, 2])
     ŷ = categorical([1, 2, 2, 2, 2, 1, 2])
-    cm = confmat(ŷ, y, warn=false)
+    cm = _confmat(ŷ, y, warn=false)
     TN = sum(ŷ .== y .== 1) # pred and true = - (1)
     TP = sum(ŷ .== y .== 2) # pred and true = + (2)
     FP = sum(ŷ .!= y .== 1) # pred + (2) and true - (1)
@@ -150,7 +150,7 @@ end
     @test cm[1,2] == FN
     @test cm[2,1] == FP
 
-    cm2 = confmat(ŷ, y; rev=true)
+    cm2 = _confmat(ŷ, y; rev=true)
     @test cm2[1,1] == cm[2,2]
     @test cm2[1,2] == cm[2,1]
     @test cm2[2,2] == cm[1,1]
@@ -185,7 +185,7 @@ end
     y = coerce([0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2], Multiclass)
     ŷ = coerce([0, 1, 0, 0, 0, 2, 1, 2, 0, 1, 1, 2], Multiclass)
     class_w = Dict(0=>0,2=>2,1=>1)
-    cm = confmat(ŷ, y, warn=false)
+    cm = _confmat(ŷ, y, warn=false)
 
     #               ┌─────────────────────────────────────────┐
     #               │              Ground Truth               │

--- a/test/measures/loss_functions_interface.jl
+++ b/test/measures/loss_functions_interface.jl
@@ -2,7 +2,10 @@ rng = StableRNG(614)
 
 # convert a Binary vector into vector of +1 or -1 values
 # (for testing only):
-pm1(y) = Int8(2) .* (Int8.(int(y))) .- Int8(3)
+pm1(y) = Int8(2) .* (Int8.(MLJBase.int(y))) .- Int8(3)
+
+const MARGIN_LOSSES = MLJBase.MARGIN_LOSSES
+const DISTANCE_LOSSES = MLJBase.DISTANCE_LOSSES
 
 @testset "LossFunctions.jl - binary" begin
     y = categorical(["yes", "yes", "no", "yes"])
@@ -13,8 +16,10 @@ pm1(y) = Int8(2) .* (Int8.(int(y))) .- Int8(3)
     X = nothing
     w = [1, 2, 3, 4]
 
-    @test MLJBase.value(ZeroOneLoss(), yhat, X, y, nothing) ≈ [1, 1, 1, 0]
-    @test MLJBase.value(ZeroOneLoss(), yhat, X, y, w) ≈ [1, 2, 3, 0] ./10 .* 4
+    @test MLJBase.value(MLJBase.ZeroOneLoss(), yhat, X, y, nothing) ≈
+        [1, 1, 1, 0]
+    @test MLJBase.value(MLJBase.zero_one_loss, yhat, X, y, w) ≈
+        [1, 2, 3, 0] ./10 .* 4
 
     N = 10
     y = categorical(rand(rng, ["yes", "no"], N), ordered=true)
@@ -22,20 +27,19 @@ pm1(y) = Int8(2) .* (Int8.(int(y))) .- Int8(3)
     no, yes = MLJBase.classes(y[1])
     @test pm1([yes, no]) in [[+1, -1], [-1, +1]]
     ym = pm1(y) # observations for raw LossFunctions measure
-    p_vec = rand(rng, N) # probabilities of yes
-    yhat  = map(p_vec) do p
-        MLJBase.UnivariateFinite([yes, no], [p, 1 - p])
-    end
+    p_vec = rand(N)
+    yhat = MLJBase.UnivariateFinite([no, yes], p_vec, augment=true)
     yhatm = MLJBase._scale.(p_vec) # predictions for raw LossFunctions measure
     w = rand(rng, N)
     X = nothing
 
-    for m in [ZeroOneLoss(), L1HingeLoss(), L2HingeLoss(), LogitMarginLoss(),
-              ModifiedHuberLoss(), PerceptronLoss(), SmoothedL1HingeLoss(0.9),
-              L2MarginLoss(), ExpLoss(), SigmoidLoss(), DWDMarginLoss(0.9)]
-        @test MLJBase.value(m, yhat, X, y, nothing) ≈ LossFunctions.value(m, yhatm, ym)
+    for M_ex in MARGIN_LOSSES
+        m = eval(:(MLJBase.$M_ex()))
+        @test MLJBase.value(m, yhat, X, y, nothing) ≈
+            LossFunctions.value(m, yhatm, ym)
         @test mean(MLJBase.value(m, yhat, X, y, w)) ≈
-                LossFunctions.value(m, yhatm, ym, AggMode.WeightedMean(w))
+            LossFunctions.value(m, yhatm, ym,
+                                LossFunctions.AggMode.WeightedMean(w))
     end
 end
 
@@ -47,12 +51,14 @@ end
     X    = nothing
     w    = rand(rng, N)
 
-    for m in [LPDistLoss(0.5), L1DistLoss(), L2DistLoss(),
-              HuberLoss(0.9), EpsilonInsLoss(0.9), L1EpsilonInsLoss(0.9),
-              L2EpsilonInsLoss(0.9), LogitDistLoss(), QuantileLoss(0.7)]
-
-        @test MLJBase.value(m, yhat, X, y, nothing) ≈ LossFunctions.value(m, yhat, y)
+    for M_ex in DISTANCE_LOSSES
+        m = eval(:(MLJBase.$M_ex()))
+        m_ex = MLJBase.snakecase(M_ex)
+        @test m == eval(:(MLJBase.$m_ex))
+        @test MLJBase.value(m, yhat, X, y, nothing) ≈
+            LossFunctions.value(m, yhat, y)
         @test mean(MLJBase.value(m, yhat, X, y, w)) ≈
-                LossFunctions.value(m, yhat, y, AggMode.WeightedMean(w))
+            LossFunctions.value(m, yhat, y,
+                                LossFunctions.AggMode.WeightedMean(w))
     end
 end

--- a/test/measures/loss_functions_interface.jl
+++ b/test/measures/loss_functions_interface.jl
@@ -36,10 +36,12 @@ const DISTANCE_LOSSES = MLJBase.DISTANCE_LOSSES
     for M_ex in MARGIN_LOSSES
         m = eval(:(MLJBase.$M_ex()))
         @test MLJBase.value(m, yhat, X, y, nothing) ≈
-            LossFunctions.value(m, yhatm, ym)
+            LossFunctions.value(m, yhatm, ym) ≈
+            m(yhat, y)
         @test mean(MLJBase.value(m, yhat, X, y, w)) ≈
             LossFunctions.value(m, yhatm, ym,
-                                LossFunctions.AggMode.WeightedMean(w))
+                                LossFunctions.AggMode.WeightedMean(w)) ≈
+                                    mean(m(yhat, y, w))
     end
 end
 
@@ -56,9 +58,12 @@ end
         m_ex = MLJBase.snakecase(M_ex)
         @test m == eval(:(MLJBase.$m_ex))
         @test MLJBase.value(m, yhat, X, y, nothing) ≈
-            LossFunctions.value(m, yhat, y)
+            LossFunctions.value(m, yhat, y) ≈
+            m(yhat, y)
         @test mean(MLJBase.value(m, yhat, X, y, w)) ≈
             LossFunctions.value(m, yhat, y,
-                                LossFunctions.AggMode.WeightedMean(w))
+                                LossFunctions.AggMode.WeightedMean(w)) ≈
+                                    mean(m(yhat ,y, w))
     end
 end
+

--- a/test/measures/measure_search.jl
+++ b/test/measures/measure_search.jl
@@ -27,5 +27,4 @@ end
 @test !("LogLoss" in ms)
 @test "RootMeanSquaredError"  in ms
 
-
 true

--- a/test/measures/measure_search.jl
+++ b/test/measures/measure_search.jl
@@ -1,7 +1,7 @@
 ms = map(measures()) do m
     m.name
 end
-@test "cross_entropy" in ms
+@test "LogLoss" in ms
 @test "RootMeanSquaredError"  in ms
 
 # test `M()` makes sense for all measure types `M` extracted from `name`,
@@ -18,13 +18,13 @@ end
 ms = map(measures(matching(categorical(1:3)))) do m
          m.name
 end
-@test "cross_entropy" in ms
+@test "LogLoss" in ms
 @test !("RootMeanSquaredError"  in ms)
 
 ms = map(measures(matching(rand(3)))) do m
          m.name
 end
-@test !("cross_entropy" in ms)
+@test !("LogLoss" in ms)
 @test "RootMeanSquaredError"  in ms
 
 

--- a/test/measures/measure_search.jl
+++ b/test/measures/measure_search.jl
@@ -5,11 +5,10 @@ end
 @test "RootMeanSquaredError"  in ms
 
 # test `M()` makes sense for all measure types `M` extracted from `name`,
-# and that all detailed doc strings are non-empty:
-@test_broken all(Symbol.(ms)) do ex
-    m = try
+@test all(Symbol.(ms)) do ex
+    try
         eval(:($ex()))
-        !isempty(MLJBase.detailed_doc_string(typeof(m)))
+        true
     catch
         false
     end

--- a/test/measures/measure_search.jl
+++ b/test/measures/measure_search.jl
@@ -2,18 +2,30 @@ ms = map(measures()) do m
     m.name
 end
 @test "cross_entropy" in ms
-@test "rms"  in ms
+@test "RootMeanSquaredError"  in ms
+
+# test `M()` makes sense for all measure types `M` extracted from `name`,
+# and that all detailed doc strings are non-empty:
+@test_broken all(Symbol.(ms)) do ex
+    m = try
+        eval(:($ex()))
+        !isempty(MLJBase.detailed_doc_string(typeof(m)))
+    catch
+        false
+    end
+end
 
 ms = map(measures(matching(categorical(1:3)))) do m
          m.name
 end
 @test "cross_entropy" in ms
-@test !("rms"  in ms)
+@test !("RootMeanSquaredError"  in ms)
 
 ms = map(measures(matching(rand(3)))) do m
          m.name
 end
 @test !("cross_entropy" in ms)
-@test "rms"  in ms
+@test "RootMeanSquaredError"  in ms
+
 
 true

--- a/test/measures/measures.jl
+++ b/test/measures/measures.jl
@@ -4,7 +4,7 @@ using MLJBase, Test
 import Distributions
 using CategoricalArrays
 using Statistics
-using LossFunctions
+import LossFunctions
 using StableRNGs
 using OrderedCollections: LittleDict
 

--- a/test/measures/measures.jl
+++ b/test/measures/measures.jl
@@ -37,8 +37,7 @@ end
     @test reports_each_observation(auc) == false
     @test is_feature_dependent(auc) == false
 
-    @test MLJBase.distribution_type(BrierScore{UnivariateFinite}) ==
-        MLJBase.UnivariateFinite
+    @test MLJBase.distribution_type(BrierScore) == MLJBase.UnivariateFinite
 end
 
 mutable struct DRegressor <: Deterministic end


### PR DESCRIPTION
This PR resolves #450:

- [x] (**enhancement**) Thorough review of measure doc-strings, including addition of automatic doc-string generation to simplify new contributions (`@create_docs` macro)

- [x] Add a new trait for measures called `human_name` (mainly for use in documentation); for example its value for `L1EpsilonInsLoss` is `l1  ϵ-insensitive loss`. There is a fallback that guesses a human name from the type name. 

- [x] (**breaking**) Redefine `name` trait on all measures to return string version of type name, eg, for `L1EpsilonInsLoss` type (or its instances) the value is "L1EpsilonLoss". This is for consistency with `name` on models. Type names have changed to make them maximally descriptive (eg, `RMS` is now `RootMeanSquaredError`) but the old names are kept as aliases.  

- [x] (**enhancement**) Add a new trait for measures called `instances` (distinct from `Base.instances` and not exported) which lists string versions of built in instances, mostly aliases for the default instance. For example, the value on `Recall` is `["true_positive_rate", "truepositive_rate", "tpr", "sensitivity", "recall", "hit_rate"]`. These instances appear second on calls to `measures()` so user to can easily lookup a short method to call in common use cases (see below)

- [x] (**enhancement**) Ensure every measure has a default keyword constructor, so, for example `FScore()` now works. 

- [x] (**breaking**) `FScore` are `BrierScore` have been simplified to avoid unnecessary type parameters; this may break some constructors, like `FScore{1.0}()`. You should never need to use `{}` to construct a measure instance. 

- [x] (**enhancement**) All types from LossFunctions.jl are exported and they now have default key-word constructors, just like the built-in measures, and their instances can be called the same way too. (In LossFunctions.jl the instances are not callable.)

- [x]  Add `BierLoss`. It is just negative of `BrierScore`. 

- [x] (**breaking**) Dissallow keyword arguments in calls to `confmat`, which is now an instance of a measure type (`confmat = ConfusionMatrix()`), rather than a function hacked to look like a measure. So, instead of `confmat(yhat, y, perm=[2, 3, 1])` use `ConfusionMatrix(perm=[2, 3, 1])(yhat, y)`.  What used to be called  `ConfusionMatrix` is now `ConfusionMatrixObject`. The ordinary user will never need to construct one directly.  

- [x] (**mildlly breaking**) The field name `eps` in `LogLoss=CrossEntropy` (for clamping) is renamed to `tol` for consistency with other measures and elsewhere in julia. However `CrossEntropy(eps=...)` still works. 


```julia
julia> measures()
59-element Array{NamedTuple{(:name, :instances, :human_name, :target_scitype, :supports_weights, :prediction_type, :orientation, :reports_each_observation, :aggregation, :is_feature_dependent, :docstring, :distribution_type, :supports_class_weights),T} where T<:Tuple,1}:
 (name = Accuracy, instances = [accuracy], ...)
 (name = AreaUnderCurve, instances = [area_under_curve, auc], ...)
 (name = BalancedAccuracy, instances = [balanced_accuracy, bacc, bac], ...)
 (name = BrierLoss, instances = [brier_loss], ...)
 (name = BrierScore, instances = [brier_score], ...)
 (name = ConfusionMatrix, instances = [confusion_matrix, confmat], ...)
 (name = FScore, instances = [f1score], ...)
 (name = FalseDiscoveryRate, instances = [false_discovery_rate, falsediscovery_rate, fdr], ...)

...

 (name = L2MarginLoss, instances = [l2_margin_loss], ...)
 (name = LogitMarginLoss, instances = [logit_margin_loss], ...)
 (name = ModifiedHuberLoss, instances = [modified_huber_loss], ...)
 (name = PerceptronLoss, instances = [perceptron_loss], ...)
 (name = SigmoidLoss, instances = [sigmoid_loss], ...)
 (name = SmoothedL1HingeLoss, instances = [smoothed_l1_hinge_loss], ...)
 (name = ZeroOneLoss, instances = [zero_one_loss], ...)
 (name = HuberLoss, instances = [huber_loss], ...)
 (name = L1EpsilonInsLoss, instances = [l1_epsilon_ins_loss], ...)
 (name = L2EpsilonInsLoss, instances = [l2_epsilon_ins_loss], ...)
 (name = LPDistLoss, instances = [lp_dist_loss], ...)
 (name = LogitDistLoss, instances = [logit_dist_loss], ...)
 (name = PeriodicLoss, instances = [periodic_loss], ...)
 (name = QuantileLoss, instances = [quantile_loss], ...)

julia> log_loss
LogLoss(
    tol = 2.220446049250313e-16) @422
```

I will be looking to merge this in about 13 hours time so that the PR for CategorialArrays [compat] bump (also breaking) can follow soon after and a minor release can go out soon. 
