### PR TITLE
Address a few things uncovered by the VS Code linter

### DIFF
--- a/src/MLJBase.jl
+++ b/src/MLJBase.jl
@@ -1,4 +1,4 @@
-module MLJBase 
+module MLJBase
 
 # ===================================================================
 # IMPORTS
@@ -134,7 +134,7 @@ export params # note this is *not* an extension of StatsBase.params
 export partition, unpack, complement, restrict, corestrict
 
 # utilities.jl:
-export @set_defaults, flat_values, recursive_setproperty!,
+export flat_values, recursive_setproperty!,
        recursive_getproperty, pretty, unwind
 
 # show.jl
@@ -162,7 +162,7 @@ export machine, Machine, fit!, report, fit_only!
 export make_blobs, make_moons, make_circles, make_regression
 
 # composition:
-export machines, sources, anonymize!, @from_network, @pipeline,
+export machines, sources, @from_network, @pipeline,
     glb, @tuple, node, @node, sources, origins, return!,
     nrows_at_source, machine,
     rebind!, nodes, freeze!, thaw!, models, Node, AbstractNode,
@@ -284,7 +284,7 @@ export DWDMarginLoss, ExpLoss, L1HingeLoss, L2HingeLoss, L2MarginLoss,
     SmoothedL1HingeLoss, ZeroOneLoss, HuberLoss, L1EpsilonInsLoss,
     L2EpsilonInsLoss, LPDistLoss, LogitDistLoss, PeriodicLoss,
     QuantileLoss
- 
+
 # -------------------------------------------------------------------
 # re-export from Random, StatsBase, Statistics, Distributions,
 # OrderedCollections, CategoricalArrays, InvertedIndices:

--- a/src/composition/learning_networks/inspection.jl
+++ b/src/composition/learning_networks/inspection.jl
@@ -102,7 +102,7 @@ function machines(W::Node, model=nothing)
                     (machines(arg) for arg in W.args)...,
                     (machines(arg) for arg in W.machine.args)...) |> unique
     end
-    model == nothing && return machs
+    model === nothing && return machs
     return filter(machs) do mach
         mach.model == model
     end

--- a/src/measures/finite.jl
+++ b/src/measures/finite.jl
@@ -4,7 +4,7 @@
 # -----------------------------------------------------
 # LogLoss
 
-struct LogLoss{R} <: Measure where R <: Real
+struct LogLoss{R <: Real} <: Measure
     tol::R
 end
 LogLoss(;eps=eps(), tol=eps) = LogLoss(tol)
@@ -107,12 +107,12 @@ function (::BrierScore)(ŷ::Vec{<:UnivariateFinite},
                         y::Vec,
                         w::Union{Nothing,Vec{<:Real}}=nothing)
     check_dimensions(ŷ, y)
-    w == nothing || check_dimensions(w, y)
+    w === nothing || check_dimensions(w, y)
 
     check_pools(ŷ, y)
     unweighted = broadcast(_brier_score, ŷ, y)
 
-    if w == nothing
+    if w === nothing
         return unweighted
     end
     return w.*unweighted
@@ -125,7 +125,7 @@ function (::BrierScore)(
     w::Union{Nothing,Vec{<:Real}}=nothing) where {S,V,R,P<:Real}
 
     check_dimensions(ŷ, y)
-    w == nothing || check_dimensions(w, y)
+    w === nothing || check_dimensions(w, y)
 
     isempty(y) && return P(0)
 
@@ -136,7 +136,7 @@ function (::BrierScore)(
 
     unweighted = P(2) .* broadcast(pdf, ŷ, y) .- offset
 
-    if w == nothing
+    if w === nothing
         return unweighted
     end
     return w.*unweighted

--- a/src/measures/measures.jl
+++ b/src/measures/measures.jl
@@ -33,7 +33,7 @@ orientation(::Type) = :loss  # other options are :score, :other
 reports_each_observation(::Type) = false
 aggregation(::Type) = Mean()  # other option is Sum() or callable object
 is_feature_dependent(::Type) = false
-human_name(::Type) = snakecase(name(M), delim=' ')
+human_name(M::Type) = snakecase(name(M), delim=' ')
 instances(::Type) = String[]
 
 # specific to `Finite` measures:

--- a/src/resampling.jl
+++ b/src/resampling.jl
@@ -445,7 +445,7 @@ function _process_accel_settings(accel::CPUThreads)
       throw(ArgumentError("`n`used in `acceleration = CPUThreads(n)`must" *
                         "be an instance of type `T<:Signed`"))
       accel.settings > 0 ||
-            throw(error("Can't create $(acceleration.settings) tasks)"))
+            throw(error("Can't create $(accel.settings) tasks)"))
       _accel = accel
     end
     return _accel
@@ -790,7 +790,7 @@ function evaluate!(mach::Machine, resampling, weights,
         fit!(mach; rows=train, verbosity=verbosity - 1, force=force)
         Xtest = selectrows(X, test)
         ytest = selectrows(y, test)
-        if weights == nothing
+        if weights === nothing
             wtest = nothing
         else
             wtest = weights[test]

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -112,7 +112,7 @@ function reduce_nested_field(ex)
     tail = ex.args[2]
     tail isa QuoteNode || throw(ArgumentError)
     field = tail.value
-    field isa Symbol || throw(ArgmentError)
+    field isa Symbol || throw(ArgumentError)
     subex = ex.args[1]
     return (subex, field)
 end


### PR DESCRIPTION
This PR addresses a few things that the VS Code linter uncovered.

The linter also recommends using `x === nothing` rather than `x == nothing`. (Actually, I prefer to use `isnothing`.)

Also, there appear to be a few whitespace changes. I have my editor set up to strip trailing whitespace characters when I save a file.