### PR TITLE
Address breaking change in LossFunctions between 0.6 and 0.6.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MLJBase"
 uuid = "a7f614a8-145f-11e9-1d2a-a57a1082229d"
 authors = ["Anthony D. Blaom <anthony.blaom@gmail.com>"]
-version = "0.16.1"
+version = "0.16.2"
 
 [deps]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"

--- a/src/measures/loss_functions_interface.jl
+++ b/src/measures/loss_functions_interface.jl
@@ -1,8 +1,14 @@
 # implementation of MLJ measure interface for LossFunctions.jl
 
 naked(T::Type) = split(string(T), '.') |> last |> Symbol
-const MARGIN_LOSSES = naked.(subtypes(MarginLoss))
-const DISTANCE_LOSSES = naked.(subtypes(DistanceLoss))
+
+const MARGIN_LOSSES =
+    [:DWDMarginLoss, :ExpLoss, :L1HingeLoss, :L2HingeLoss, :L2MarginLoss,
+     :LogitMarginLoss, :ModifiedHuberLoss, :PerceptronLoss, :SigmoidLoss,
+     :SmoothedL1HingeLoss, :ZeroOneLoss]
+const DISTANCE_LOSSES =
+    [:HuberLoss, :L1EpsilonInsLoss, :L2EpsilonInsLoss, :LPDistLoss,
+     :LogitDistLoss, :PeriodicLoss, :QuantileLoss]
 
 # Supervised Loss -- measure traits
 const LSF = LossFunctions


### PR DESCRIPTION
Between these versions of LossFunctions, `ScaledDistanceLoss` went from a type to a function. Auto-generation of the list of distance losses in MLJ was not robust to this. This PR explicitly lists the losses to be re-exported to address this, and to head off similar problems in future. 