### PR TITLE
Docs: set `push_preview=false`

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -27,5 +27,5 @@ ENV["TRAVIS_PULL_REQUEST"] = "false"
 
 deploydocs(;
            repo="github.com/alan-turing-institute/MLJBase.jl.git",
-           push_preview=true
+           push_preview=false,
 )

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -53,6 +53,6 @@ including:
 
 Previously MLJBase provided the model interface for integrating third
 party machine learning models into MLJ. That role has now shifted to
-the light-weight
+the lightweight
 [MLJModelInterface](https://github.com/alan-turing-institute/MLJModelInterface.jl)
 package.


### PR DESCRIPTION
Docs build should still work even if `push_preview=false`.

`push_preview` should only affect PR previews. It should have no effect on pushes to `master`.