### PR TITLE
Relax dimension check in machine constructor

### DIFF
--- a/src/machines.jl
+++ b/src/machines.jl
@@ -105,7 +105,8 @@ function check(model::Supervised, args... ; full=false)
          nowarns=false)
 
     # checks on dimension matching:
-    nrows(X()) == nrows(y()) ||
+
+    scitype(X) == CallableReturning{Nothing} || nrows(X()) == nrows(y()) ||
         throw(DimensionMismatch("Differing number of observations "*
                                 "in input and target. "))
 

--- a/test/interface/model_api.jl
+++ b/test/interface/model_api.jl
@@ -28,5 +28,57 @@ rng = StableRNG(661)
     @test_throws ArgumentError predict_mode(rgs, fitresult, X)
 end
 
+mutable struct UnivariateFiniteFitter <: MLJModelInterface.Probabilistic
+    alpha::Float64
+end
+UnivariateFiniteFitter(;alpha=1.0) = UnivariateFiniteFitter(alpha)
+
+@testset "models that fit a distribution" begin
+    function MLJModelInterface.fit(model::UnivariateFiniteFitter,
+                               verbosity, X, y)
+
+        α = model.alpha
+        N = length(y)
+        _classes = classes(y)
+        d = length(_classes)
+
+        frequency_given_class = Distributions.countmap(y)
+        prob_given_class =
+            Dict(c => (frequency_given_class[c] + α)/(N + α*d) for c in _classes)
+
+        fitresult = MLJBase.UnivariateFinite(prob_given_class)
+
+        report = (params=Distributions.params(fitresult),)
+        cache = nothing
+
+        verbosity > 0 && @info "Fitted a $fitresult"
+
+        return fitresult, cache, report
+    end
+
+    MLJModelInterface.predict(model::UnivariateFiniteFitter,
+                              fitresult,
+                              X) = fitresult
+
+
+    MLJModelInterface.input_scitype(::Type{<:UnivariateFiniteFitter}) =
+        Nothing
+    MLJModelInterface.target_scitype(::Type{<:UnivariateFiniteFitter}) =
+        AbstractVector{<:Finite}
+
+    y = coerce(collect("aabbccaa"), Multiclass)
+    X = nothing
+    model = UnivariateFiniteFitter(alpha=0)
+    mach = machine(model, X, y)
+    fit!(mach, verbosity=0)
+
+    ytest = y[1:3]
+    yhat = predict(mach, nothing) # single UnivariateFinite distribution
+
+    @test cross_entropy(fill(yhat, 3), ytest) ≈
+        [-log(1/2), -log(1/2), -log(1/4)]
+
+end
+
 end
 true


### PR DESCRIPTION
This PR removes the dimension check for `X, y` in `machine(model, X, y)` if `X === nothing`, allowing us to tweak the API for models that fit a distrubution. It also adds a check that the new API can be implemented without problems. 

This PR is non-breaking. 