### PR TITLE
Fixed a spelling mistake in pipeline error message

### DIFF
--- a/src/composition/models/pipelines.jl
+++ b/src/composition/models/pipelines.jl
@@ -128,7 +128,7 @@ not_unsupervised_alert(v) =
 pipe_argument_error(v) =
     pipe_alert("Encountered `$v` where a "*
                "model instance, model type, function, "*
-               "or key-word assignement was expected. ")
+               "or key-word assignment was expected. ")
 
 function super_type(prediction_type::Symbol)
     if prediction_type == :deterministic


### PR DESCRIPTION
In the MLJ pipeline error message, the word ```assignment``` is misspelled as ```assignement```. This PR fixes that!

Here's a screenshot of the error message
![image](https://user-images.githubusercontent.com/49980787/113102733-0a087c80-921c-11eb-848a-8ff8462d0232.png)
