### PR TITLE
Run CI on Julia nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
         version:
           - '1.0'
           - '1' # automatically expands to the latest stable 1.x release of Julia.
+          - 'nightly'
         os:
           - ubuntu-latest
         arch:


### PR DESCRIPTION
This will be useful for CompatHelper. On Julia nightly, CompatHelper workflows will now fail if they are not able to use the new version of the dependency.

This feature requires Julia 1.7, and thus is currently only available in Julia nightly.