### PR TITLE
Ensure Resampler does not generate new train/test pairs unless `resampling` or `repeats` changes

### DIFF
--- a/src/resampling.jl
+++ b/src/resampling.jl
@@ -999,21 +999,13 @@ to the prescribed `resampling` strategy and other parameters, using
 data `args...`, by calling `fit!(mach)` followed by
 `evaluate(mach)`.
 
-The resampler internally binds `model` to the supplied data `args` in
-a machine (called `mach_train` below) on which `evaluate!` is called
-with all the options passed to the `Resampler` constructor. The
-advantage over using `evaluate(model, args...)` directly is:
-
-(i) New train/test folds are not regenerated on subsequent `fit!(mach)`
-calls unless `model` has changed, even when `shuffle` is `true` in
-the chosen resampling strategy; and
-
-(ii) If there is only one train/test pair (for example `resampling =
-Holdout` and `repeats = 1`) then re-evaluation of the model triggered
-by subsequent calls to `fit!(mach)` will not trigger a cold restart of
-`train_mach`, unless `resampling` or `repeats` has changed. This is
-desirable in applicationis to `TunedModel` and crucial for applicatons
-to `IteratedModel`.
+On subsequent calls to `fit!(mach)` new train/test pairs of row
+indices are only regenerated if `resampling`, `repeats` or `cache`
+fields of `resampler` have changed (even in the case of RNG-dependent
+`resampling` strategy). If there is single train/test pair, then
+warm-restart behavior of the wrapped model `resampler.model` will
+extend to warm-restart behaviour of the wrapper `resampler`, with
+respect to mutations of the wrapped model.
 
 The sample `weights` are passed to the specified performance measures
 that support weights for evaluation. These weights are not to be
@@ -1190,4 +1182,3 @@ function evaluate(machine::Machine{<:Resampler})
         throw(error("$machine has not been trained."))
     end
 end
-

--- a/src/resampling.jl
+++ b/src/resampling.jl
@@ -1001,11 +1001,14 @@ data `args...`, by calling `fit!(mach)` followed by
 
 On subsequent calls to `fit!(mach)` new train/test pairs of row
 indices are only regenerated if `resampling`, `repeats` or `cache`
-fields of `resampler` have changed (even in the case of RNG-dependent
-`resampling` strategy). If there is single train/test pair, then
-warm-restart behavior of the wrapped model `resampler.model` will
-extend to warm-restart behaviour of the wrapper `resampler`, with
-respect to mutations of the wrapped model.
+fields of `resampler` have changed. The evolution of an RNG field of
+`resampler` does *not* constitute a change (`==` for `MLJType` objects
+is not sensitive to such changes; see [`is_same_except'](@ref)). 
+
+If there is single train/test pair, then warm-restart behavior of the
+wrapped model `resampler.model` will extend to warm-restart behaviour
+of the wrapper `resampler`, with respect to mutations of the wrapped
+model.
 
 The sample `weights` are passed to the specified performance measures
 that support weights for evaluation. These weights are not to be

--- a/src/resampling.jl
+++ b/src/resampling.jl
@@ -302,7 +302,8 @@ const PerformanceEvaluation = NamedTuple{(:measure,
                                           :per_fold,
                                           :per_observation,
                                           :fitted_params_per_fold,
-                                          :report_per_fold)}
+                                          :report_per_fold,
+                                          :train_test_rows)}
 
 # pretty printing:
 round3(x) = x
@@ -323,6 +324,7 @@ function Base.show(io::IO, ::MIME"text/plain", e::PerformanceEvaluation)
     println(io, "_.per_observation = $(_short(e.per_observation))")
     println(io, "_.fitted_params_per_fold = [ … ]")
     println(io, "_.report_per_fold = [ … ]")
+    println(io, "_.train_test_rows = [ … ]")
 end
 
 function Base.show(io::IO, e::PerformanceEvaluation)
@@ -654,7 +656,7 @@ function evaluate!(mach::Machine{<:Supervised};
         end
         if repeats != 1 && verbosity > 0
             @warn "repeats > 1 not supported unless "*
-            "`resampling<:ResamplingStrategy. "
+            "`resampling <: ResamplingStrategy. "
         end
     end
 
@@ -940,7 +942,8 @@ function evaluate!(mach::Machine, resampling, weights,
            per_fold               = per_fold,
            per_observation        = per_observation,
            fitted_params_per_fold = fitted_params_per_fold |> collect,
-           report_per_fold        = report_per_fold |> collect)
+           report_per_fold        = report_per_fold |> collect,
+           train_test_rows       = resampling)
 
     return ret
 
@@ -987,8 +990,8 @@ end
                           check_measure=true)
 
 Resampling model wrapper, used internally by the `fit` method of
-`TunedModel` instances. See [`evaluate!](@ref) for options. Not
-intended for general use.
+`TunedModel` instances and `IteratedModel` instances. See
+[`evaluate!](@ref) for options. Not intended for general use.
 
 Given a machine `mach = machine(resampler, args...)` one obtains a
 performance evaluation of the specified `model`, performed according
@@ -999,9 +1002,18 @@ data `args...`, by calling `fit!(mach)` followed by
 The resampler internally binds `model` to the supplied data `args` in
 a machine (called `mach_train` below) on which `evaluate!` is called
 with all the options passed to the `Resampler` constructor. The
-advantage over using `evaluate(model, args...)` directly is that, for
-`Holdout` resampling, calling `fit!(mach)` only triggers a cold
-restart of `mach_train` if necessary.
+advantage over using `evaluate(model, args...)` directly is:
+
+(i) New train/test folds are not regenerated on subsequent `fit!(mach)`
+calls unless `model` has changed, even when `shuffle` is `true` in
+the chosen resampling strategy; and
+
+(ii) If there is only one train/test pair (for example `resampling =
+Holdout` and `repeats = 1`) then re-evaluation of the model triggered
+by subsequent calls to `fit!(mach)` will not trigger a cold restart of
+`train_mach`, unless `resampling` or `repeats` has changed. This is
+desirable in applicationis to `TunedModel` and crucial for applicatons
+to `IteratedModel`.
 
 The sample `weights` are passed to the specified performance measures
 that support weights for evaluation. These weights are not to be
@@ -1081,7 +1093,7 @@ function MLJModelInterface.fit(resampler::Resampler, verbosity::Int, args...)
 
     mach = machine(resampler.model, args...; cache=resampler.cache)
 
-    measures =
+    _measures =
         _process_weights_measures(resampler.weights,
                                   resampler.class_weights,
                                   resampler.measure,
@@ -1099,54 +1111,47 @@ function MLJModelInterface.fit(resampler::Resampler, verbosity::Int, args...)
                   nothing,
                   verbosity - 1,
                   resampler.repeats,
-                  measures,
+                  _measures,
                   resampler.operation,
                   _acceleration,
                   false)
 
-    fitresult = (machine=mach, evaluation=e)
-    cache = deepcopy(resampler.resampling)
+    fitresult = (machine = mach, evaluation = e)
+    cache = (resampler = deepcopy(resampler),
+             acceleration = _acceleration)
     report =(evaluation = e, )
 
     return fitresult, cache, report
 
 end
 
-# in special case of non-shuffled, non-repeated holdout, we can reuse
-# the underlying model's machine, provided the training_fraction has
-# not changed:
-function MLJModelInterface.update(resampler::Resampler{Holdout},
-                        verbosity::Int, fitresult, cache, args...)
+function MLJModelInterface.update(resampler::Resampler,
+                                  verbosity::Int,
+                                  fitresult,
+                                  cache,
+                                  args...)
 
-    old_resampling = cache
-    old_mach = fitresult.machine
+    old_resampler, acceleration = cache
 
-    reusable = !resampler.resampling.shuffle &&
-        resampler.repeats == 1 &&
-        old_resampling.fraction_train ==
-        resampler.resampling.fraction_train
-
-    if reusable
-        mach = old_mach
-    else
-        mach = machine(resampler.model, args...; cache=resampler.cache)
-        cache = (mach, deepcopy(resampler.resampling))
+    # if we need to generate new train/test pairs, or data caching
+    # option has changed, then fit from scratch:
+    if resampler.resampling != old_resampler.resampling ||
+        resampler.repeats != old_resampler.repeats ||
+        resampler.cache != old_resampler.cache
+        return MLJModelInterface.fit(resampler, verbosity, args...)
     end
 
-    measures =
-        _process_weights_measures(resampler.weights,
-                                  resampler.class_weights,
-                                  resampler.measure,
-                                  mach,
-                                  resampler.operation,
-                                  verbosity,
-                                  resampler.check_measure)
+    mach, e = fitresult
+    train_test_rows = e.train_test_rows
 
-    _acceleration = _process_accel_settings(resampler.acceleration)
+    measures = e.measure
 
+    # update the model:
     mach.model = resampler.model
+
+    # re-evaluate:
     e = evaluate!(mach,
-                  resampler.resampling,
+                  train_test_rows,
                   resampler.weights,
                   resampler.class_weights,
                   nothing,
@@ -1154,15 +1159,18 @@ function MLJModelInterface.update(resampler::Resampler{Holdout},
                   resampler.repeats,
                   measures,
                   resampler.operation,
-                  _acceleration,
+                  acceleration,
                   false)
 
     report = (evaluation = e, )
     fitresult = (machine=mach, evaluation=e)
+    cache = (resampler = deepcopy(resampler),
+             acceleration = acceleration)
 
     return fitresult, cache, report
 
 end
+
 
 StatisticalTraits.input_scitype(::Type{<:Resampler{S,M}}) where {S,M} =
     StatisticalTraits.input_scitype(M)


### PR DESCRIPTION
This PR fixes a bug in the `Resampler` code. Recall that `Resampler` is a model wrapper for repetitive performance evaluation of models and is used by the `TunedModel` and `IterativeModel` wrappers, although it is not a public object. 

Here is how the bug manifests at present: Suppose you are tuning a single hyper-parameter using the `resampling=Holdout(rng=123)` option for the resampling strategy. Then you expect a single randomised train/test pair of rows to be created, and for the same pair to be used for each hyper-parameter value to be evaluated. However, at present, for each new hyper-parameter value, a new train/test pair of rows is generated. As the RNG has evolved after each evaluation, this new pair is *different* each time!

If one is not shuffling, then the bug does not manifest, the likely reason this was not detected earlier. I scold my earlier self for not writing better tests here. 

A second problem with re-generating the train/test pairs every evalutation is that it rules out the possibility of a warm-restart for certain parameter changes, such as an iteration parameter. For this reason, `IteratedModel` was very slow when specifying a *shuffled* holdout (see  https://github.com/JuliaAI/MLJIteration.jl/issues/12).

The source of the bug is a flawed implementation of `update` for the `Resampler` object which is repaired in this PR by only generating new train/test rows if `resampling` or `repeats` changes (or if the `cache` option changes, as this requires a new training machine to be generated).  

The solution in this PR depends on the addition of a field to the evaluation object, namely `train_test_rows`, for recording the actual train/test pairs of row indices.

This PR also addresses the issue about user-specified holdout sets mentioned in this comment: https://github.com/alan-turing-institute/MLJTuning.jl/issues/82#issuecomment-708048992