### PR TITLE
Tighten return type of predict for KNNClassifier (model for testing)

### DIFF
--- a/test/_models/NearestNeighbors.jl
+++ b/test/_models/NearestNeighbors.jl
@@ -134,7 +134,7 @@ function MLJBase.predict(m::KNNClassifier, (tree, y, w), Xmatrix)
         probas ./= sum(probas)
         preds[i] = MLJBase.UnivariateFinite(classes, probas)
     end
-    return preds
+    return [preds...]
 end
 
 function MLJBase.predict(m::KNNRegressor, (tree, y, w), Xmatrix)


### PR DESCRIPTION
Recall that MLJBase has its own local versions of models for testing. In some new tests in another PR, a small issue arises from the return type of KNNClassifier not being quite right, and this PR fixes this.

 This only effects test code.