### PR TITLE
Fix computation of Matthews correlation coefficient

### DIFF
--- a/src/measures/finite.jl
+++ b/src/measures/finite.jl
@@ -354,7 +354,7 @@ function (::MCC)(cm::ConfusionMatrixObject{C}) where C
         b = sum(cm[:, setdiff(1:C, k)])
         den2 += a * b
     end
-    mcc = num / sqrt(den1 * den2)
+    mcc = num / sqrt(float(den1) * float(den2))
 
     isnan(mcc) && return 0
     return mcc

--- a/test/measures/finite.jl
+++ b/test/measures/finite.jl
@@ -84,6 +84,10 @@ end
     # invariance with respect to permutation ?
     cm = MLJBase._confmat(ŷ, y, perm=[3, 1, 2, 4])
     @test mcc(cm) ≈ sk_mcc
+
+    # Issue #381
+    cm = MLJBase.ConfusionMatrixObject([29488 13017; 12790 29753], ["0.0", "1.0"])
+    @test mcc(cm) ≈ 0.39312321239417797
 end
 
 @testset "AUC" begin


### PR DESCRIPTION
`den1` and `den2` are `Int`, when they get large enough multiplying them can
result in overflow.  The solution is to convert them to float before multiplying
them and computing the square root.

Fix #381.