### PR TITLE
Enable `evaluate!` to infer automatically different operations for different measures

### DIFF
--- a/src/MLJBase.jl
+++ b/src/MLJBase.jl
@@ -43,7 +43,8 @@ import Dates
 # Distributed computing
 using Distributed
 using ComputationalResources
-using ComputationalResources: CPUProcesses
+import ComputationalResources: CPU1, CPUProcesses, CPUThreads
+
 using ProgressMeter
 import .Threads
 
@@ -102,6 +103,9 @@ export fit, update, update_data, transform, inverse_transform,
 # data operations
 export matrix, int, classes, decoder, table,
     nrows, selectrows, selectcols, select
+
+# re-export from ComputationalResources.jl:
+export CPU1, CPUProcesses, CPUThreads
 
 # re-exports from ScientificTypes
 export Unknown, Known, Finite, Infinite,

--- a/src/measures/measures.jl
+++ b/src/measures/measures.jl
@@ -49,6 +49,8 @@ end
 
 # display:
 show_as_constructed(::Type{<:Measure}) = true
+show_compact(::Type{<:Measure}) = true
+Base.show(io::IO, m::Measure) = show(io, MIME("text/plain"), m)
 
 # info (see also src/init.jl):
 function ScientificTypes.info(M, ::Val{:measure_type})

--- a/src/operations.jl
+++ b/src/operations.jl
@@ -22,8 +22,13 @@
 ## TODO: need to add checks on the arguments of
 ## predict(::Machine, ) and transform(::Machine, )
 
-const OPERATIONS = (:predict, :predict_mean, :predict_mode, :predict_median,
-                    :predict_joint, :transform, :inverse_transform)
+const PREDICT_OPERATIONS = (:predict,
+                            :predict_mean,
+                            :predict_mode,
+                            :predict_median,
+                            :predict_joint)
+
+const OPERATIONS = tuple(PREDICT_OPERATIONS..., :transform, :inverse_transform)
 
 _err_rows_not_allowed() =
     throw(ArgumentError("Calling `transform(mach, rows=...)` when "*

--- a/src/show.jl
+++ b/src/show.jl
@@ -108,9 +108,12 @@ end
 crind(n) = "\n"*repeat(' ', max(n, 0))
 
 # trait to tag those objects to be displayed as constructed:
-show_as_constructed(::Any) = false
+show_as_constructed(::Type) = false
 show_as_constructed(::Type{<:Model}) = true
+show_compact(::Type) = false
 
+show_as_constructed(object) = show_as_constructed(typeof(object))
+show_compact(object) = show_compact(typeof(object))
 
 # simplified string rep of an Type:
 function simple_repr(T)
@@ -167,8 +170,8 @@ end
 fancy(stream::IO, object) = fancy(stream, object, 0,
                                   DEFAULT_AS_CONSTRUCTED_SHOW_DEPTH, 0)
 fancy(stream, object, current_depth, depth, n) = show(stream, object)
-function fancy(stream, object::MLJType, current_depth, depth, n) 
-    if current_depth == depth
+function fancy(stream, object::MLJType, current_depth, depth, n)
+    if current_depth == depth ;;;;;
         show(stream, object)
     else
         prefix = MLJModelInterface.name(object)
@@ -178,7 +181,8 @@ function fancy(stream, object::MLJType, current_depth, depth, n)
         n_names = length(names)
         for k in eachindex(names)
             value =  getproperty(object, names[k])
-            print(stream, crind(n + length(prefix) - anti))
+            show_compact(object) ||
+                print(stream, crind(n + length(prefix) - anti))
             print(stream, "$(names[k]) = ")
             fancy(stream, value, current_depth + 1, depth, n + length(prefix)
                   - anti + length("$k = "))

--- a/test/composition/learning_networks/machines.jl
+++ b/test/composition/learning_networks/machines.jl
@@ -44,7 +44,7 @@ MLJBase.predict(model::DummyClusterer, fitresult, Xnew) =
     mach = machine(Unsupervised(), Xs; predict=yhat, transform=Wout)
     @test mach.args == (Xs, )
     @test mach.args[1] == Xs
-    fit!(mach, force=true)
+    fit!(mach, force=true, verbosity=0)
 
     report(mach)
     fitted_params(mach)
@@ -60,19 +60,19 @@ MLJBase.predict(model::DummyClusterer, fitresult, Xnew) =
     @test_throws ArgumentError machine(Probabilistic(), Xs, ys)
 
     # supervised - predict_mode
-    fit!(mach)
+    fit!(mach, verbosity=0)
     @test predict_mode(mach, X) == mode.(predict(mach, X))
     @test predict(mach, rows=1:2) == predict(mach, rows=:)[1:2]
 
     # evaluate a learning machine
-    evaluate!(mach, measure=LogLoss())
+    evaluate!(mach, measure=LogLoss(), verbosity=0)
 
     # supervised - predict_median, predict_mean
     X, y = make_regression(20)
     Xs = source(X); ys = source(y)
     mm = machine(ConstantRegressor(), Xs, ys)
     yhat = predict(mm, Xs)
-    mach = machine(Probabilistic(), Xs, ys; predict=yhat) |> fit!
+    mach = fit!(machine(Probabilistic(), Xs, ys; predict=yhat), verbosity=0)
     @test predict_mean(mach, X) ≈ mean.(predict(mach, X))
     @test predict_median(mach, X) ≈ median.(predict(mach, X))
 
@@ -103,7 +103,7 @@ yhat = exp(zhat)
 
 @testset "replace method for learning network machines" begin
 
-    fit!(yhat)
+    fit!(yhat, verbosity=0)
 
     # test nested reporting:
     r = MLJBase.report(yhat)

--- a/test/composition/learning_networks/nodes.jl
+++ b/test/composition/learning_networks/nodes.jl
@@ -22,7 +22,7 @@ y = 2X.x1  - X.x2 + 0.05*rand(N);
     ys = source(y)
     mach1 = machine(Standardizer(), Xs)
     W = transform(mach1, Xs)
-    fit!(W)
+    fit!(W, verbosity=0)
     @test_logs((:error, r"Failed"), @test_throws Exception W(34))
 
     mach2 = machine(DecisionTreeClassifier(), W, ys)

--- a/test/composition/models/_wrapped_function.jl
+++ b/test/composition/models/_wrapped_function.jl
@@ -5,7 +5,7 @@ using Test
 using MLJBase
 
 t  = MLJBase.WrappedFunction(f=log)
-f, = fit(t, 1)
+f, = fit(t, 0)
 @test transform(t, f, 5) ≈ log(5)
 
 end

--- a/test/composition/models/from_network.jl
+++ b/test/composition/models/from_network.jl
@@ -51,7 +51,7 @@ mach_, modeltype_ex, struct_ex, no_fields, dic =
     MLJBase.from_network_preprocess(TestFromComposite, mach_ex, ex)
 eval(Parameters.with_kw(struct_ex, TestFromComposite, false))
 @test supertype(CompositeX) == DeterministicComposite
-composite = CompositeX()
+composite = CompositeX();;;
 @test composite.knn_rgs == knn
 @test composite.one_hot_enc == hot
 @test dic[:target_scitype] == :(AbstractVector{<:Continuous})
@@ -362,8 +362,8 @@ rgs = ConstantClassifier() # supports weights
 rgsM = machine(rgs, W, ys, ws)
 yhat = predict(rgsM, W)
 
-fit!(yhat)
-fit!(yhat, rows=1:div(N,2))
+fit!(yhat, verbosity=0)
+fit!(yhat, rows=1:div(N,2), verbosity=0)
 yhat(rows=1:div(N,2));
 
 mach = machine(Probabilistic(), Xs, ys, ws; predict=yhat)
@@ -377,7 +377,7 @@ end
 
 my_composite = MyComposite()
 @test MLJBase.supports_weights(my_composite)
-mach = fit!(machine(my_composite, X, y))
+mach = fit!(machine(my_composite, X, y), verbosity=0)
 Xnew = selectrows(X, 1:div(N,2))
 predict(mach, Xnew)[1]
 posterior = predict(mach, Xnew)[1]
@@ -387,7 +387,7 @@ posterior = predict(mach, Xnew)[1]
 @test abs(pdf(posterior, 'b')/(pdf(posterior, 'c'))  - 1) < 0.15
 
 # now add weights:
-mach = fit!(machine(my_composite, X, y, w), rows=1:div(N,2))
+mach = fit!(machine(my_composite, X, y, w), rows=1:div(N,2), verbosity=0)
 posterior = predict(mach, Xnew)[1]
 
 # "posterior" is skewed appropriately in weighted case:
@@ -401,7 +401,7 @@ mach = machine(Probabilistic(), Xs, ys, ws; predict=yhat)
     end
 end
 composite_with_no_fields = CompositeWithNoFields()
-mach = fit!(machine(composite_with_no_fields, X, y))
+mach = fit!(machine(composite_with_no_fields, X, y), verbosity=0)
 
 
 ## EXPORTING A TRANSFORMER WITH PREDICT AND TRANSFORM
@@ -434,7 +434,7 @@ clust = DummyClusterer(n=2)
 m = machine(clust, W)
 yhat = predict(m, W)
 Wout = transform(m, W)
-fit!(glb(yhat, Wout))
+fit!(glb(yhat, Wout), verbosity=0)
 mach = machine(Unsupervised(), Xs; predict=yhat, transform=Wout)
 
 @from_network mach begin
@@ -445,7 +445,7 @@ mach = machine(Unsupervised(), Xs; predict=yhat, transform=Wout)
 end
 
 model = WrappedClusterer()
-mach = fit!(machine(model, X))
+mach = fit!(machine(model, X), verbosity=0)
 @test predict(mach, X) == yhat()
 @test transform(mach, X).a ≈ Wout().a
 
@@ -472,9 +472,9 @@ Z = 2*W
     end
 end
 
-mach = machine(NoTraining()) |> fit!
+mach = fit!(machine(NoTraining()), verbosity=0)
 @test transform(mach, X) == 2*X.age
-
+ 
 
 ## TESTINGS A STACK AND IN PARTICULAR FITTED_PARAMS
 
@@ -585,6 +585,5 @@ mach = machine(model, X, y)
                         fit!(mach, verbosity=-1)))
 
 end
-
 
 true

--- a/test/composition/models/inspection.jl
+++ b/test/composition/models/inspection.jl
@@ -41,7 +41,7 @@ target_stand = UnivariateStandardizer()
 model = Bar(scale, rgs, input_stand, target_stand)
 
 mach = machine(model, X, y)
-fit!(mach)
+fit!(mach, verbosity=0)
 
 @testset "user-friendly inspection of reports and fitted params" begin
 
@@ -90,7 +90,7 @@ end
     end
 
     model = Mixer(KNNRegressor(), KNNRegressor(), 42)
-    mach = machine(model, make_regression(10, 3)...) |> fit!
+    mach = fit!(machine(model, make_regression(10, 3)...), verbosity=0)
     fp = fitted_params(mach)
     @test !(fp.model1 isa Vector)
     @test !(fp.model2 isa Vector)

--- a/test/composition/models/methods.jl
+++ b/test/composition/models/methods.jl
@@ -29,7 +29,7 @@ X, y = make_regression(10, 2)
     mach1 = machine(model.model_in_network, W, ys)
     yhat = predict(mach1, W)
     mach = machine(Deterministic(), Xs, ys; predict=yhat)
-    fitresult, cache, _ = return!(mach, model, 1)
+    fitresult, cache, _ = return!(mach, model, 0)
     @test cache.network_model_names == [:model_in_network, nothing]
     old_model = cache.old_model
     network_model_names = cache.network_model_names
@@ -97,7 +97,8 @@ function MLJBase.fit(model::Rubbish, verbosity, X, y)
     return!(mach, model, verbosity)
 end
 
-mach = machine(model, X, y) |> fit! # `model` is instance of `Rubbish`
+# `model` is instance of `Rubbish`
+mach = fit!(machine(model, X, y), verbosity=0)
 
 @testset "logic for composite model update - fit!" begin
 
@@ -198,10 +199,10 @@ selector_model = FeatureSelector()
 
     mach = machine(composite, Xs, ys)
     yhat = predict(mach, Xs)
-    fit!(yhat, verbosity=3)
+    fit!(yhat, verbosity=0)
     composite.transformer.features = [:b, :c]
-    fit!(yhat, verbosity=3)
-    fit!(yhat, rows=1:20, verbosity=3)
+    fit!(yhat, verbosity=0)
+    fit!(yhat, rows=1:20, verbosity=0)
     yhat(MLJBase.selectrows(Xin, test));
 
 end
@@ -242,11 +243,11 @@ end
     model_ = WrappedRidge(ridge)
     mach = machine(model_, Xin, yin)
     id = objectid(mach)
-    fit!(mach)
+    fit!(mach, verbosity=0)
     @test  objectid(mach) == id  # *********
     yhat=predict(mach, Xin);
     ridge.lambda = 1.0
-    fit!(mach)
+    fit!(mach, verbosity=0)
     @test predict(mach, Xin) != yhat
 
 #end
@@ -289,9 +290,9 @@ WrappedDummyClusterer(; model=DummyClusterer()) =
     end
     X, _ = make_regression(10, 5);
     model = WrappedDummyClusterer(model=DummyClusterer(n=2))
-    mach = machine(model, X) |> fit!
+    mach = fit!(machine(model, X), verbosity=0)
     model.model.n = 3
-    fit!(mach)
+    fit!(mach, verbosity=0)
     @test transform(mach, X) == selectcols(X, 1:3)
     r = report(mach)
     @test r.model.centres == MLJBase.matrix(X)[1:3,:]

--- a/test/composition/models/static_transformers.jl
+++ b/test/composition/models/static_transformers.jl
@@ -19,7 +19,7 @@ MLJBase.transform(transf::YourTransformer, verbosity, X) =
 @testset "nodal machine constructor for static transformers" begin
     X = (x1=rand(3), x2=[1, 2, 3]);
     mach = machine(YourTransformer(:x2))
-    fit!(mach)
+    fit!(mach, verbosity=0)
     @test transform(mach, X) == [1, 2, 3]
 end
 

--- a/test/machines.jl
+++ b/test/machines.jl
@@ -67,14 +67,14 @@ end
 
     # without weights:
     mach = machine(ConstantClassifier(), X, y)
-    fit!(mach)
+    fit!(mach, verbosity=0)
     d1 = predict(mach, X)[1]
     d2 = MLJBase.UnivariateFinite([y[1], y[2], y[4]], [0.5, 0.25, 0.25])
     @test all([pdf(d1, c) ≈ pdf(d2, c) for c in MLJBase.classes(d1)])
 
     # with weights:
     mach = machine(ConstantClassifier(), X, y, w)
-    fit!(mach)
+    fit!(mach, verbosity=0)
     d1 = predict(mach, X)[1]
     d2 = MLJBase.UnivariateFinite([y[1], y[2], y[4]], [1/3, 1/4, 5/12])
     @test all([pdf(d1, c) ≈ pdf(d2, c) for c in MLJBase.classes(d1)])

--- a/test/operations.jl
+++ b/test/operations.jl
@@ -6,11 +6,11 @@ using ..Models
 
 @testset "error for operations on nodes" begin
     X = rand(4)
-    m = machine(UnivariateStandardizer(), X) |> fit!
+    m = fit!(machine(UnivariateStandardizer(), X), verbosity=0)
     @test_throws ArgumentError inverse_transform(m)
 #    @test_deprecated transform(m)
     X = source(rand(4))
-    m = machine(UnivariateStandardizer(), X) |> fit!
+    m = fit!(machine(UnivariateStandardizer(), X), verbosity=0)
     @test_throws ArgumentError inverse_transform(m)
 #    @test_deprecated transform(m)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -106,4 +106,3 @@ end
     @test include("hyperparam/one_dimensional_ranges.jl")
     @test include("hyperparam/one_dimensional_range_methods.jl")
 end
-

--- a/test/test_utilities.jl
+++ b/test/test_utilities.jl
@@ -63,9 +63,9 @@ macro test_mach_sequence(fit_ex, sequence_exs...)
         MLJBase.flush!(MLJBase.MACHINE_CHANNEL)
         $fit_ex
         $seq = MLJBase.flush!(MLJBase.MACHINE_CHANNEL)
-        for s in $seq
-            println(s)
-        end
+        # for s in $seq
+        #     println(s)
+        # end
         @test $seq in [$(sequence_exs...)]
     end)
 end
@@ -83,9 +83,9 @@ macro test_model_sequence(fit_ex, sequence_exs...)
         $seq = map(MLJBase.flush!(MLJBase.MACHINE_CHANNEL)) do tup
             (tup[1], tup[2].model)
         end
-        for s in $seq
-            println(s)
-        end
+        # for s in $seq
+        #     println(s)
+        # end
         @test $seq in [$(sequence_exs...)]
     end)
 end


### PR DESCRIPTION
Addresses #598 according to [this suggestion](https://github.com/alan-turing-institute/MLJ.jl/issues/795#issuecomment-848374803). 

(This enhancement should mitigate greatly one of the most common gotchas for beginner users.)

Also improves the `show` for measures, to make printed output of evaluate less ambiguous.

My apologies for the messy PR - the 4th commit, which changes a lot of files, is only to suppress noisy logging during tests.  The key commits to review are the 3rd and 5th commits. 

From the updated doc-string from `evaluate!`:

---

The type of operation (`predict`, `predict_mode`, etc) to be
associated with `measure` is automatically inferred from measure
traits where possible. For example, `predict_mode` will be used for a
`Multiclass` target, if `model` is probabilistic but `measure` is
deterministic. Abmiguities, such as `predict_mean`/`predict_median`
are logged to `Info`. To suppress the logging, lower `verbosity` or
explicitly specify `operation=...`. If `measure` is a vector, then any
`operation` specified must be a single operation, which will be
associated with all measures, or a vector of the same length.

