### PR TITLE
Alternative to #599 with less logging

### DIFF
--- a/src/MLJBase.jl
+++ b/src/MLJBase.jl
@@ -43,7 +43,8 @@ import Dates
 # Distributed computing
 using Distributed
 using ComputationalResources
-using ComputationalResources: CPUProcesses
+import ComputationalResources: CPU1, CPUProcesses, CPUThreads
+
 using ProgressMeter
 import .Threads
 
@@ -102,6 +103,9 @@ export fit, update, update_data, transform, inverse_transform,
 # data operations
 export matrix, int, classes, decoder, table,
     nrows, selectrows, selectcols, select
+
+# re-export from ComputationalResources.jl:
+export CPU1, CPUProcesses, CPUThreads
 
 # re-exports from ScientificTypes
 export Unknown, Known, Finite, Infinite,

--- a/src/measures/measures.jl
+++ b/src/measures/measures.jl
@@ -49,6 +49,8 @@ end
 
 # display:
 show_as_constructed(::Type{<:Measure}) = true
+show_compact(::Type{<:Measure}) = true
+Base.show(io::IO, m::Measure) = show(io, MIME("text/plain"), m)
 
 # info (see also src/init.jl):
 function ScientificTypes.info(M, ::Val{:measure_type})

--- a/src/operations.jl
+++ b/src/operations.jl
@@ -22,8 +22,13 @@
 ## TODO: need to add checks on the arguments of
 ## predict(::Machine, ) and transform(::Machine, )
 
-const OPERATIONS = (:predict, :predict_mean, :predict_mode, :predict_median,
-                    :predict_joint, :transform, :inverse_transform)
+const PREDICT_OPERATIONS = (:predict,
+                            :predict_mean,
+                            :predict_mode,
+                            :predict_median,
+                            :predict_joint)
+
+const OPERATIONS = tuple(PREDICT_OPERATIONS..., :transform, :inverse_transform)
 
 _err_rows_not_allowed() =
     throw(ArgumentError("Calling `transform(mach, rows=...)` when "*

--- a/src/operations.jl
+++ b/src/operations.jl
@@ -28,7 +28,7 @@ const PREDICT_OPERATIONS = (:predict,
                             :predict_median,
                             :predict_joint)
 
-const OPERATIONS = tuple(PREDICT_OPERATIONS..., :transform, :inverse_transform)
+const OPERATIONS = (PREDICT_OPERATIONS..., :transform, :inverse_transform)
 
 _err_rows_not_allowed() =
     throw(ArgumentError("Calling `transform(mach, rows=...)` when "*

--- a/src/resampling.jl
+++ b/src/resampling.jl
@@ -635,7 +635,7 @@ function _actual_operations(operation::Nothing,
             if prediction_type === :probabilistic
                 throw(err_incompatible_prediction_types(model, m))
             elseif prediction_type === :deterministic
-                    return predict
+                return predict
             else
                 throw(err_ambiguous_operation(model, m))
             end

--- a/src/resampling.jl
+++ b/src/resampling.jl
@@ -26,7 +26,7 @@ _ambiguous_operation(model, measure) =
     "`prediction_type($model) == $(prediction_type(model))`."
 err_ambiguous_operation(model, measure) = ArgumentError(
     _ambiguous_operation(model, measure)*
-    "\n Unable to deduce an appropriate operation for $measure. "*
+    "\nUnable to deduce an appropriate operation for $measure. "*
     "Explicitly specify `operation=...` or `operations=...`. ")
 err_incompatible_prediction_types(model, measure) = ArgumentError(
     _ambiguous_operation(model, measure))

--- a/src/resampling.jl
+++ b/src/resampling.jl
@@ -2,7 +2,7 @@ const PREDICT_OPERATIONS_STRING = begin
     strings = map(PREDICT_OPERATIONS) do op
         "`"*string(op)*"`"
     end
-    join(strings, ", ")
+    join(strings, ", ", ", or ")
 end
 const ERR_WEIGHTS_REAL =
     ArgumentError("`weights` must be a `Real` vector. ")

--- a/src/resampling.jl
+++ b/src/resampling.jl
@@ -1083,7 +1083,7 @@ function evaluate!(mach::Machine, resampling, weights,
         end
         ytest = selectrows(y, test)
 
-        measurements =  map(zip(measures, operations)) do (m, op)
+        measurements =  map(measures, operations) do m, op
             wtest = measure_specific_weights(m,
                                              weights,
                                              class_weights,

--- a/src/resampling.jl
+++ b/src/resampling.jl
@@ -452,8 +452,8 @@ function Base.show(io::IO, ::MIME"text/plain", e::PerformanceEvaluation)
     data = hcat(e.measure, round3.(e.measurement), e.operation,
                 [round3.(v) for v in e.per_fold])
     header = ["measure", "measurement", "operation", "per_fold"]
-    println(io, "tabular PerformanceEvaluation object "*
-            "with these fields (columns):")
+    println(io, "PerformanceEvaluation object "*
+            "with these fields:")
     println(io, "  measure, measurement, operation, per_fold,\n"*
             "  per_observation, fitted_params_per_fold,\n"*
             "  report_per_fold, train_test_pairs")

--- a/src/resampling.jl
+++ b/src/resampling.jl
@@ -814,9 +814,8 @@ these properties:
 - `operation`: for each measure, the operation applied; one of:
   $PREDICT_OPERATIONS_STRING.
 
-- `per_fold`: a vector of vectors of
-
-- individual test fold evaluations (one vector per measure)
+- `per_fold`: a vector of vectors of individual test fold evaluations
+  (one vector per measure)
 
 - `per_observation`: a vector of vectors of individual observation
   evaluations of those measures for which

--- a/src/resampling.jl
+++ b/src/resampling.jl
@@ -15,7 +15,7 @@ const ERR_WEIGHTS_DICT =
 const ERR_WEIGHTS_CLASSES =
     DimensionMismatch("The keys of `class_weights` "*
                       "are not the same as the levels of the "*
-                      "target, y`. Do `levels(y)` to check levels. ")
+                      "target, `y`. Do `levels(y)` to check levels. ")
 const ERR_OPERATION_MEASURE_MISMATCH = DimensionMismatch(
     "The number of operations and the number of measures are different. ")
 const ERR_INVALID_OPERATION = ArgumentError(

--- a/src/resampling.jl
+++ b/src/resampling.jl
@@ -498,29 +498,29 @@ function _check_measure(measure, operation, model, y)
             "\nscitype of target = $T but target_scitype($measure) = "*
             "$(target_scitype(measure))."*avoid))
 
-    if model isa Probabilistic
-        if operation == predict
-            if prediction_type(measure) != :probabilistic
-                if target_scitype(measure) <:
-                    AbstractVector{<:Union{Missing,Finite}}
-                    suggestion = "\nPerhaps you want to set `operation="*
-                        "predict_mode` or need to "*
-                        "specify multiple operations, "*
-                        "one for each measure. "
-                elseif target_scitype(measure) <:
-                    AbstractVector{<:Union{Missing,Continuous}}
-                    suggestion = "\nPerhaps you want to set `operation="*
-                        "predict_mean` or `operation=predict_median`, or "*
-                        "specify multiple operations, "*
-                        "one for each measure. "
-                else
-                    suggestion = ""
-                end
-                throw(ArgumentError(
-                   "\n$model <: Probabilistic but prediction_type($measure) = "*
-                      ":$(prediction_type(measure)). "*suggestion*avoid))
-            end
+    incompatible = model isa Probabilistic &&
+        operation == predict &&
+        prediction_type(measure) != :probabilistic
+
+    if incompatible
+        if target_scitype(measure) <:
+            AbstractVector{<:Union{Missing,Finite}}
+            suggestion = "\nPerhaps you want to set `operation="*
+                "predict_mode` or need to "*
+                "specify multiple operations, "*
+                "one for each measure. "
+        elseif target_scitype(measure) <:
+            AbstractVector{<:Union{Missing,Continuous}}
+            suggestion = "\nPerhaps you want to set `operation="*
+                "predict_mean` or `operation=predict_median`, or "*
+                "specify multiple operations, "*
+                "one for each measure. "
+        else
+            suggestion = ""
         end
+        throw(ArgumentError(
+            "\n$model <: Probabilistic but prediction_type($measure) = "*
+            ":$(prediction_type(measure)). "*suggestion*avoid))
     end
 
     model isa Deterministic && prediction_type(measure) != :deterministic &&

--- a/src/show.jl
+++ b/src/show.jl
@@ -171,7 +171,7 @@ fancy(stream::IO, object) = fancy(stream, object, 0,
                                   DEFAULT_AS_CONSTRUCTED_SHOW_DEPTH, 0)
 fancy(stream, object, current_depth, depth, n) = show(stream, object)
 function fancy(stream, object::MLJType, current_depth, depth, n)
-    if current_depth == depth ;;;;;
+    if current_depth == depth
         show(stream, object)
     else
         prefix = MLJModelInterface.name(object)

--- a/src/show.jl
+++ b/src/show.jl
@@ -108,9 +108,12 @@ end
 crind(n) = "\n"*repeat(' ', max(n, 0))
 
 # trait to tag those objects to be displayed as constructed:
-show_as_constructed(::Any) = false
+show_as_constructed(::Type) = false
 show_as_constructed(::Type{<:Model}) = true
+show_compact(::Type) = false
 
+show_as_constructed(object) = show_as_constructed(typeof(object))
+show_compact(object) = show_compact(typeof(object))
 
 # simplified string rep of an Type:
 function simple_repr(T)
@@ -167,8 +170,8 @@ end
 fancy(stream::IO, object) = fancy(stream, object, 0,
                                   DEFAULT_AS_CONSTRUCTED_SHOW_DEPTH, 0)
 fancy(stream, object, current_depth, depth, n) = show(stream, object)
-function fancy(stream, object::MLJType, current_depth, depth, n) 
-    if current_depth == depth
+function fancy(stream, object::MLJType, current_depth, depth, n)
+    if current_depth == depth ;;;;;
         show(stream, object)
     else
         prefix = MLJModelInterface.name(object)
@@ -178,7 +181,8 @@ function fancy(stream, object::MLJType, current_depth, depth, n)
         n_names = length(names)
         for k in eachindex(names)
             value =  getproperty(object, names[k])
-            print(stream, crind(n + length(prefix) - anti))
+            show_compact(object) ||
+                print(stream, crind(n + length(prefix) - anti))
             print(stream, "$(names[k]) = ")
             fancy(stream, value, current_depth + 1, depth, n + length(prefix)
                   - anti + length("$k = "))

--- a/test/composition/learning_networks/machines.jl
+++ b/test/composition/learning_networks/machines.jl
@@ -44,7 +44,7 @@ MLJBase.predict(model::DummyClusterer, fitresult, Xnew) =
     mach = machine(Unsupervised(), Xs; predict=yhat, transform=Wout)
     @test mach.args == (Xs, )
     @test mach.args[1] == Xs
-    fit!(mach, force=true)
+    fit!(mach, force=true, verbosity=0)
 
     report(mach)
     fitted_params(mach)
@@ -60,19 +60,19 @@ MLJBase.predict(model::DummyClusterer, fitresult, Xnew) =
     @test_throws ArgumentError machine(Probabilistic(), Xs, ys)
 
     # supervised - predict_mode
-    fit!(mach)
+    fit!(mach, verbosity=0)
     @test predict_mode(mach, X) == mode.(predict(mach, X))
     @test predict(mach, rows=1:2) == predict(mach, rows=:)[1:2]
 
     # evaluate a learning machine
-    evaluate!(mach, measure=LogLoss())
+    evaluate!(mach, measure=LogLoss(), verbosity=0)
 
     # supervised - predict_median, predict_mean
     X, y = make_regression(20)
     Xs = source(X); ys = source(y)
     mm = machine(ConstantRegressor(), Xs, ys)
     yhat = predict(mm, Xs)
-    mach = machine(Probabilistic(), Xs, ys; predict=yhat) |> fit!
+    mach = fit!(machine(Probabilistic(), Xs, ys; predict=yhat), verbosity=0)
     @test predict_mean(mach, X) ≈ mean.(predict(mach, X))
     @test predict_median(mach, X) ≈ median.(predict(mach, X))
 
@@ -103,7 +103,7 @@ yhat = exp(zhat)
 
 @testset "replace method for learning network machines" begin
 
-    fit!(yhat)
+    fit!(yhat, verbosity=0)
 
     # test nested reporting:
     r = MLJBase.report(yhat)

--- a/test/composition/learning_networks/nodes.jl
+++ b/test/composition/learning_networks/nodes.jl
@@ -22,7 +22,7 @@ y = 2X.x1  - X.x2 + 0.05*rand(N);
     ys = source(y)
     mach1 = machine(Standardizer(), Xs)
     W = transform(mach1, Xs)
-    fit!(W)
+    fit!(W, verbosity=0)
     @test_logs((:error, r"Failed"), @test_throws Exception W(34))
 
     mach2 = machine(DecisionTreeClassifier(), W, ys)

--- a/test/composition/models/_wrapped_function.jl
+++ b/test/composition/models/_wrapped_function.jl
@@ -5,7 +5,7 @@ using Test
 using MLJBase
 
 t  = MLJBase.WrappedFunction(f=log)
-f, = fit(t, 1)
+f, = fit(t, 0)
 @test transform(t, f, 5) ≈ log(5)
 
 end

--- a/test/composition/models/from_network.jl
+++ b/test/composition/models/from_network.jl
@@ -51,7 +51,7 @@ mach_, modeltype_ex, struct_ex, no_fields, dic =
     MLJBase.from_network_preprocess(TestFromComposite, mach_ex, ex)
 eval(Parameters.with_kw(struct_ex, TestFromComposite, false))
 @test supertype(CompositeX) == DeterministicComposite
-composite = CompositeX()
+composite = CompositeX();;;
 @test composite.knn_rgs == knn
 @test composite.one_hot_enc == hot
 @test dic[:target_scitype] == :(AbstractVector{<:Continuous})
@@ -362,8 +362,8 @@ rgs = ConstantClassifier() # supports weights
 rgsM = machine(rgs, W, ys, ws)
 yhat = predict(rgsM, W)
 
-fit!(yhat)
-fit!(yhat, rows=1:div(N,2))
+fit!(yhat, verbosity=0)
+fit!(yhat, rows=1:div(N,2), verbosity=0)
 yhat(rows=1:div(N,2));
 
 mach = machine(Probabilistic(), Xs, ys, ws; predict=yhat)
@@ -377,7 +377,7 @@ end
 
 my_composite = MyComposite()
 @test MLJBase.supports_weights(my_composite)
-mach = fit!(machine(my_composite, X, y))
+mach = fit!(machine(my_composite, X, y), verbosity=0)
 Xnew = selectrows(X, 1:div(N,2))
 predict(mach, Xnew)[1]
 posterior = predict(mach, Xnew)[1]
@@ -387,7 +387,7 @@ posterior = predict(mach, Xnew)[1]
 @test abs(pdf(posterior, 'b')/(pdf(posterior, 'c'))  - 1) < 0.15
 
 # now add weights:
-mach = fit!(machine(my_composite, X, y, w), rows=1:div(N,2))
+mach = fit!(machine(my_composite, X, y, w), rows=1:div(N,2), verbosity=0)
 posterior = predict(mach, Xnew)[1]
 
 # "posterior" is skewed appropriately in weighted case:
@@ -401,7 +401,7 @@ mach = machine(Probabilistic(), Xs, ys, ws; predict=yhat)
     end
 end
 composite_with_no_fields = CompositeWithNoFields()
-mach = fit!(machine(composite_with_no_fields, X, y))
+mach = fit!(machine(composite_with_no_fields, X, y), verbosity=0)
 
 
 ## EXPORTING A TRANSFORMER WITH PREDICT AND TRANSFORM
@@ -434,7 +434,7 @@ clust = DummyClusterer(n=2)
 m = machine(clust, W)
 yhat = predict(m, W)
 Wout = transform(m, W)
-fit!(glb(yhat, Wout))
+fit!(glb(yhat, Wout), verbosity=0)
 mach = machine(Unsupervised(), Xs; predict=yhat, transform=Wout)
 
 @from_network mach begin
@@ -445,7 +445,7 @@ mach = machine(Unsupervised(), Xs; predict=yhat, transform=Wout)
 end
 
 model = WrappedClusterer()
-mach = fit!(machine(model, X))
+mach = fit!(machine(model, X), verbosity=0)
 @test predict(mach, X) == yhat()
 @test transform(mach, X).a ≈ Wout().a
 
@@ -472,9 +472,9 @@ Z = 2*W
     end
 end
 
-mach = machine(NoTraining()) |> fit!
+mach = fit!(machine(NoTraining()), verbosity=0)
 @test transform(mach, X) == 2*X.age
-
+ 
 
 ## TESTINGS A STACK AND IN PARTICULAR FITTED_PARAMS
 
@@ -585,6 +585,5 @@ mach = machine(model, X, y)
                         fit!(mach, verbosity=-1)))
 
 end
-
 
 true

--- a/test/composition/models/from_network.jl
+++ b/test/composition/models/from_network.jl
@@ -51,7 +51,7 @@ mach_, modeltype_ex, struct_ex, no_fields, dic =
     MLJBase.from_network_preprocess(TestFromComposite, mach_ex, ex)
 eval(Parameters.with_kw(struct_ex, TestFromComposite, false))
 @test supertype(CompositeX) == DeterministicComposite
-composite = CompositeX();;;
+composite = CompositeX()
 @test composite.knn_rgs == knn
 @test composite.one_hot_enc == hot
 @test dic[:target_scitype] == :(AbstractVector{<:Continuous})

--- a/test/composition/models/inspection.jl
+++ b/test/composition/models/inspection.jl
@@ -41,7 +41,7 @@ target_stand = UnivariateStandardizer()
 model = Bar(scale, rgs, input_stand, target_stand)
 
 mach = machine(model, X, y)
-fit!(mach)
+fit!(mach, verbosity=0)
 
 @testset "user-friendly inspection of reports and fitted params" begin
 
@@ -90,7 +90,7 @@ end
     end
 
     model = Mixer(KNNRegressor(), KNNRegressor(), 42)
-    mach = machine(model, make_regression(10, 3)...) |> fit!
+    mach = fit!(machine(model, make_regression(10, 3)...), verbosity=0)
     fp = fitted_params(mach)
     @test !(fp.model1 isa Vector)
     @test !(fp.model2 isa Vector)

--- a/test/composition/models/methods.jl
+++ b/test/composition/models/methods.jl
@@ -29,7 +29,7 @@ X, y = make_regression(10, 2)
     mach1 = machine(model.model_in_network, W, ys)
     yhat = predict(mach1, W)
     mach = machine(Deterministic(), Xs, ys; predict=yhat)
-    fitresult, cache, _ = return!(mach, model, 1)
+    fitresult, cache, _ = return!(mach, model, 0)
     @test cache.network_model_names == [:model_in_network, nothing]
     old_model = cache.old_model
     network_model_names = cache.network_model_names
@@ -97,7 +97,8 @@ function MLJBase.fit(model::Rubbish, verbosity, X, y)
     return!(mach, model, verbosity)
 end
 
-mach = machine(model, X, y) |> fit! # `model` is instance of `Rubbish`
+# `model` is instance of `Rubbish`
+mach = fit!(machine(model, X, y), verbosity=0)
 
 @testset "logic for composite model update - fit!" begin
 
@@ -198,10 +199,10 @@ selector_model = FeatureSelector()
 
     mach = machine(composite, Xs, ys)
     yhat = predict(mach, Xs)
-    fit!(yhat, verbosity=3)
+    fit!(yhat, verbosity=0)
     composite.transformer.features = [:b, :c]
-    fit!(yhat, verbosity=3)
-    fit!(yhat, rows=1:20, verbosity=3)
+    fit!(yhat, verbosity=0)
+    fit!(yhat, rows=1:20, verbosity=0)
     yhat(MLJBase.selectrows(Xin, test));
 
 end
@@ -242,11 +243,11 @@ end
     model_ = WrappedRidge(ridge)
     mach = machine(model_, Xin, yin)
     id = objectid(mach)
-    fit!(mach)
+    fit!(mach, verbosity=0)
     @test  objectid(mach) == id  # *********
     yhat=predict(mach, Xin);
     ridge.lambda = 1.0
-    fit!(mach)
+    fit!(mach, verbosity=0)
     @test predict(mach, Xin) != yhat
 
 #end
@@ -289,9 +290,9 @@ WrappedDummyClusterer(; model=DummyClusterer()) =
     end
     X, _ = make_regression(10, 5);
     model = WrappedDummyClusterer(model=DummyClusterer(n=2))
-    mach = machine(model, X) |> fit!
+    mach = fit!(machine(model, X), verbosity=0)
     model.model.n = 3
-    fit!(mach)
+    fit!(mach, verbosity=0)
     @test transform(mach, X) == selectcols(X, 1:3)
     r = report(mach)
     @test r.model.centres == MLJBase.matrix(X)[1:3,:]

--- a/test/composition/models/static_transformers.jl
+++ b/test/composition/models/static_transformers.jl
@@ -19,7 +19,7 @@ MLJBase.transform(transf::YourTransformer, verbosity, X) =
 @testset "nodal machine constructor for static transformers" begin
     X = (x1=rand(3), x2=[1, 2, 3]);
     mach = machine(YourTransformer(:x2))
-    fit!(mach)
+    fit!(mach, verbosity=0)
     @test transform(mach, X) == [1, 2, 3]
 end
 

--- a/test/machines.jl
+++ b/test/machines.jl
@@ -67,14 +67,14 @@ end
 
     # without weights:
     mach = machine(ConstantClassifier(), X, y)
-    fit!(mach)
+    fit!(mach, verbosity=0)
     d1 = predict(mach, X)[1]
     d2 = MLJBase.UnivariateFinite([y[1], y[2], y[4]], [0.5, 0.25, 0.25])
     @test all([pdf(d1, c) ≈ pdf(d2, c) for c in MLJBase.classes(d1)])
 
     # with weights:
     mach = machine(ConstantClassifier(), X, y, w)
-    fit!(mach)
+    fit!(mach, verbosity=0)
     d1 = predict(mach, X)[1]
     d2 = MLJBase.UnivariateFinite([y[1], y[2], y[4]], [1/3, 1/4, 5/12])
     @test all([pdf(d1, c) ≈ pdf(d2, c) for c in MLJBase.classes(d1)])

--- a/test/operations.jl
+++ b/test/operations.jl
@@ -6,11 +6,11 @@ using ..Models
 
 @testset "error for operations on nodes" begin
     X = rand(4)
-    m = machine(UnivariateStandardizer(), X) |> fit!
+    m = fit!(machine(UnivariateStandardizer(), X), verbosity=0)
     @test_throws ArgumentError inverse_transform(m)
 #    @test_deprecated transform(m)
     X = source(rand(4))
-    m = machine(UnivariateStandardizer(), X) |> fit!
+    m = fit!(machine(UnivariateStandardizer(), X), verbosity=0)
     @test_throws ArgumentError inverse_transform(m)
 #    @test_deprecated transform(m)
 end

--- a/test/resampling.jl
+++ b/test/resampling.jl
@@ -53,10 +53,9 @@ MLJBase.prediction_type(::typeof(dummy_measure_interval)) = :interval
     # handling of a measure with `:unknown` `prediction_type` (eg,
     # custom measure):
     my_mae(yhat, y) = abs.(yhat - y)
-    @test(@test_logs(
-    (:info, MLJBase.info_ambiguous_operation_using_predict(rgs_det, my_mae)),
-        MLJBase._actual_operations(nothing, [my_mae, LPLoss()], rgs_det , 1)) ==
-          [predict, predict])
+    @test(
+        MLJBase._actual_operations(nothing, [my_mae, LPLoss()], rgs_det , 1) ==
+        [predict, predict])
 
     @test MLJBase._actual_operations(predict, [LogLoss(),], clf, 1) ==
         [predict,]
@@ -71,10 +70,8 @@ MLJBase.prediction_type(::typeof(dummy_measure_interval)) = :interval
     @test(
        @test_logs MLJBase._actual_operations(nothing, [Accuracy(),], clf, 1) ==
            [predict_mode])
-    @test(
-       @test_logs((:info, MLJBase.info_ambiguous_operation_using_mean(rgs, l2)),
-                  MLJBase._actual_operations(nothing, [l2,], rgs, 1) ==
-                  [predict_mean, ]))
+    @test MLJBase._actual_operations(nothing, [l2,], rgs, 1) ==
+        [predict_mean, ]
     @test_throws(MLJBase.err_incompatible_prediction_types(clf_det, LogLoss()),
                  MLJBase._actual_operations(nothing, [LogLoss(),], clf_det, 1))
     @test MLJBase._actual_operations(nothing, measures_det, clf_det, 1) ==

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -106,4 +106,3 @@ end
     @test include("hyperparam/one_dimensional_ranges.jl")
     @test include("hyperparam/one_dimensional_range_methods.jl")
 end
-

--- a/test/test_utilities.jl
+++ b/test/test_utilities.jl
@@ -63,9 +63,9 @@ macro test_mach_sequence(fit_ex, sequence_exs...)
         MLJBase.flush!(MLJBase.MACHINE_CHANNEL)
         $fit_ex
         $seq = MLJBase.flush!(MLJBase.MACHINE_CHANNEL)
-        for s in $seq
-            println(s)
-        end
+        # for s in $seq
+        #     println(s)
+        # end
         @test $seq in [$(sequence_exs...)]
     end)
 end
@@ -83,9 +83,9 @@ macro test_model_sequence(fit_ex, sequence_exs...)
         $seq = map(MLJBase.flush!(MLJBase.MACHINE_CHANNEL)) do tup
             (tup[1], tup[2].model)
         end
-        for s in $seq
-            println(s)
-        end
+        # for s in $seq
+        #     println(s)
+        # end
         @test $seq in [$(sequence_exs...)]
     end)
 end


### PR DESCRIPTION
Continuation of #599, implementing variation suggested at https://github.com/JuliaAI/MLJBase.jl/pull/599#issuecomment-890143115

```julia
julia> e = evaluate(model, X, y, measures=[LogLoss(), Accuracy()])
Evaluating over 6 folds: 100%[=========================] Time: 0:00:00
PerformanceEvaluation object with these fields:
  measure, measurement, operation, per_fold,
  per_observation, fitted_params_per_fold,
  report_per_fold, train_test_pairs
extract:
┌─────────────────────────────────┬─────────────┬──────────────┬──────────────────────────────────────────────────┐
│ measure                         │ measurement │ operation    │ per_fold                                         │
├─────────────────────────────────┼─────────────┼──────────────┼──────────────────────────────────────────────────┤
│ LogLoss(tol = 2.22045e-16) @362 │ 1.08        │ predict      │ [2.22e-16, 2.22e-16, 2.12, 2.12, 2.25, 2.22e-16] │
│ Accuracy() @097                 │ 0.97        │ predict_mode │ [1.0, 1.0, 0.941, 0.941, 0.938, 1.0]             │
└─────────────────────────────────┴─────────────┴──────────────┴──────────────────────────────────────────────────┘
```