### PR TITLE
Prohibit use of `target` as kwarg in `Pipeline(...)`

### DIFF
--- a/src/composition/models/pipelines2.jl
+++ b/src/composition/models/pipelines2.jl
@@ -137,7 +137,13 @@ const ERR_MIXED_PIPELINE_SPEC = ArgumentError(
     "Either specify all pipeline components without names, as in "*
     "`Pipeline(model1, model2)` or specify names for all "*
     "components, as in `Pipeline(myfirstmodel=model1, mysecondmodel=model2)`. ")
-
+const ERR_USING_TARGET_KWARG = ArgumentError(
+    "You are not permitted to name a pipeline component \"target\", "*
+    "as this may be confused with the `target` keyword argument for "*
+    "the older `@pipeline` macro. `Pipeline` does not support target "*
+    "transformations. To implement one, wrap a supervised "*
+    "`model` using `TransformedTargetModel`, as in "*
+    "`TransformedTargetModel(model, target=Standardizer())`. ")
 
 # The following combines its arguments into a named tuple, performing
 # a number of checks and modifications. Specifically, it checks
@@ -270,6 +276,7 @@ function Pipeline(args...; prediction_type=nothing,
     # construct the named tuple of components:
     if isempty(args)
         _names = keys(kwargs)
+        :target in _names && throw(ERR_USING_TARGET_KWARG)
         _components = values(values(kwargs))
     else
         _names = Symbol[]
@@ -285,7 +292,11 @@ function Pipeline(args...; prediction_type=nothing,
 
     named_components = pipe_named_tuple(_names, components)
 
-    _pipeline(named_components, prediction_type, operation, cache)
+    pipe = _pipeline(named_components, prediction_type, operation, cache)
+    message = clean!(pipe)
+    isempty(message) || @warn message
+
+    return pipe
 end
 
 function _pipeline(named_components::NamedTuple,
@@ -346,7 +357,6 @@ function _pipeline(named_components::NamedTuple,
 
     # dispatch on `super_type` to construct the appropriate type:
     _pipeline(super_type, operation, named_components, cache)
-
 end
 
 # where the method called in the last line will be one of these:
@@ -357,6 +367,11 @@ for T_ex in SUPPORTED_TYPES_FOR_PIPELINES
             $P_ex(args...)
     end |> eval
 end
+
+
+# # CLEAN METHOD
+
+clean!(pipe::SomePipeline) = ""
 
 
 # # PROPERTY ACCESS

--- a/test/composition/models/pipelines2.jl
+++ b/test/composition/models/pipelines2.jl
@@ -93,6 +93,7 @@ end
     @test_logs @test Pipeline(m, t, u, d, u) isa DeterministicPipeline
 
     # named components:
+    @test_throws MLJBase.ERR_USING_TARGET_KWARG Pipeline(target=u)
     @test Pipeline(c1=m, c2=t, c3=u) isa UnsupervisedPipeline
     @test Pipeline(c1=m, c2=t, c3=u, c5=p) isa ProbabilisticPipeline
     @test Pipeline(c1=m, c2=t) isa StaticPipeline


### PR DESCRIPTION
A keen user has already tried to pass `target=...` in the new `Pipeline()` constructor, which does not support this option of `@pipeline` but instead silently treats `target` as the *name* to be given to some model in the pipeline. 

So this PR throws an informative error instead.