### PR TITLE
fix `@pipeline` when MLJ is not in `Main`

### DIFF
--- a/src/composition/models/from_network.jl
+++ b/src/composition/models/from_network.jl
@@ -36,7 +36,7 @@ _insert_subtyping(ex, subtype_ex) =
 
 # create the exported type symbol, e.g. abstract_type(T) == Unsupervised
 # would result in :UnsupervisedComposite
-_exported_type(T::Model) = Symbol(abstract_type(T), :Composite)
+_exported_type(T::Model) = Symbol(nameof(abstract_type(T)), :Composite)
 
 function eval_and_reassign(modl, ex)
     s = gensym()


### PR DESCRIPTION
The `Symbol` function returns a different value whether or not the
module of the value is defined in the `Main` module. To circumvent
this, one can use `nameof` to always get only the name.

This allows `@pipeline` to be used in other modules without running
`using MLJ` in `Main`. Fixing https://github.com/fonsp/Pluto.jl/issues/1658.

Example of the Symbol behavior:

```julia
julia> module MyMod
           using MLJ
           
           print(Symbol(OneHotEncoder() |> MLJ.abstract_type))
       end
MLJModelInterface.UnsupervisedMain.MyMod

julia> using MLJ # use MLJ in Main

julia> module MyMod
           using MLJ
           
           print(Symbol(OneHotEncoder() |> MLJ.abstract_type))
       end
WARNING: replacing module MyMod.
UnsupervisedMain.MyMod

julia> # the printed symbol is not the same
```

I don't really know where I could add a test for this, since it requires not having `MLJ` in `Main`. Do you have any suggestions ?