### PR TITLE
Fix `iteration_parameter` for pipelines in case supervised component has value `nothing`

### DIFF
--- a/src/composition/models/pipelines.jl
+++ b/src/composition/models/pipelines.jl
@@ -591,23 +591,24 @@ end
 
 # ## Traits
 
-# We cannot provide the following trait at the level of types because
+# We cannot provide the following traits at the level of types because
 # the pipeline type does not know the precise type of the supervised
 # component, only its `abstract_type`. See comment at top of page.
-supports_training_losses(pipe::SupervisedPipeline) =
-    supports_training_losses(getproperty(pipe, supervised_component_name(pipe)))
 
-function training_losses(pipe::SupervisedPipeline, pipe_report)
+MMI.supports_training_losses(pipe::SupervisedPipeline) =
+    MMI.supports_training_losses(getproperty(pipe, supervised_component_name(pipe)))
+
+function MMI.training_losses(pipe::SupervisedPipeline, pipe_report)
     mach = supervised(pipe_report.machines)
     _report = report(mach)
     return training_losses(mach.model, _report)
 end
 
 # This trait cannot be defined at the level of types (see previous comment):
-function iteration_parameter(pipe::SupervisedPipeline)
+function MMI.iteration_parameter(pipe::SupervisedPipeline)
     model = supervised_component(pipe)
     name =  supervised_component_name(pipe)
     MLJBase.prepend(name, iteration_parameter(model))
 end
 
-target_scitype(p::SupervisedPipeline) = target_scitype(supervised_component(p))
+MMI.target_scitype(p::SupervisedPipeline) = target_scitype(supervised_component(p))

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -47,22 +47,26 @@ function reduce_nested_field(ex)
 end
 
 """
-    prepend(s::Symbol, s::Symbol)
+    MLJBase.prepend(::Symbol, ::Union{Symbol,Expr,Nothing})
 
 For prepending symbols in expressions like `:(y.w)` and `:(x1.x2.x3)`.
 
-julia> compose(:x, :y)
+julia> prepend(:x, :y)
 :(x.y)
 
-julia> compose(:x, :(y.z))
+julia> prepend(:x, :(y.z))
 :(x.y.z)
 
-julia> compose(:w, ans)
+julia> prepend(:w, ans)
 :(w.x.y.z)
 
+If the second argument is `nothing`, then `nothing` is returned.
+
 """
+prepend(s::Symbol, ::Nothing) = nothing
 prepend(s::Symbol, t::Symbol) = Expr(:(.), s, QuoteNode(t))
 prepend(s::Symbol, ex::Expr) = Expr(:(.), prepend(s, ex.args[1]), ex.args[2])
+
 
 """
     recursive_getproperty(object, nested_name::Expr)

--- a/test/_models/MultivariateStats.jl
+++ b/test/_models/MultivariateStats.jl
@@ -97,13 +97,13 @@ function MLJBase.fit(model::PCA, verbosity::Int, X)
                        mean=model.mean)
 
     cache = nothing
-    report = (indim=MS.indim(fitresult),
-              outdim=MS.outdim(fitresult),
+    report = (indim=size(fitresult)[1],
+              outdim=size(fitresult)[2],
               mean=MS.mean(fitresult),
               principalvars=MS.principalvars(fitresult),
               tprincipalvar=MS.tprincipalvar(fitresult),
               tresidualvar=MS.tresidualvar(fitresult),
-              tvar=MS.tvar(fitresult))
+              tvar=MS.var(fitresult))
 
     return fitresult, cache, report
 end
@@ -114,7 +114,7 @@ MLJBase.fitted_params(::PCA, fr) = (projection=fr,)
 function MLJBase.transform(::PCA, fr::PCAFitResultType, X)
     # X is n x d, need to transpose and copy twice...
     Xarray = MLJBase.matrix(X)
-    Xnew   = permutedims(MS.transform(fr, permutedims(Xarray)))
+    Xnew   = permutedims(MS.predict(fr, permutedims(Xarray)))
     return MLJBase.table(Xnew, prototype=X)
 end
 

--- a/test/composition/models/pipelines.jl
+++ b/test/composition/models/pipelines.jl
@@ -328,6 +328,13 @@ doubler(y) = 2*y
 
 end
 
+struct FooCarrot <: Deterministic end
+
+@testset "iteration parameter - nothing passes through" begin
+    pipe = FeatureSelector() |> FooCarrot()
+    @test iteration_parameter(pipe) === nothing
+end
+
 @testset "training_losses" begin
     model = MyDeterministic(:bla)
     pipe = Standardizer() |> model

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -38,6 +38,7 @@ end
 
 @testset "prepend" begin
     MLJBase.prepend(:x, :(y.z.w)) == :(x.y.z.w)
+    MLJBase.prepend(:x, nothing) == nothing
 end
 
 @testset "recursive getproperty, setproperty!" begin


### PR DESCRIPTION
Currently, if `iteration_parameter(supervised_model) == nothing` for a supervised component in a `Pipeline`, `pipe`, then `iteration_parameter(pipe)` throws an error. 

This PR fixes this (and addresses some dep warnings from test pkg MultivariateStats.jl).