### PR TITLE
Allow user to control the level of scitype checks in `machine` constructor

### DIFF
--- a/src/MLJBase.jl
+++ b/src/MLJBase.jl
@@ -94,6 +94,9 @@ using Statistics, LinearAlgebra, Random, InteractiveUtils
 # ===================================================================
 ## CONSTANTS
 
+const HANDLE_GIVEN_ID = Dict{UInt64,Symbol}()
+const SHOW_COLOR = true
+
 const PREDICT_OPERATIONS = (:predict,
                             :predict_mean,
                             :predict_mode,

--- a/src/MLJBase.jl
+++ b/src/MLJBase.jl
@@ -94,8 +94,7 @@ using Statistics, LinearAlgebra, Random, InteractiveUtils
 # ===================================================================
 ## CONSTANTS
 
-const HANDLE_GIVEN_ID = Dict{UInt64,Symbol}()
-const SHOW_COLOR = true
+# for variable global constants, see src/init.jl
 
 const PREDICT_OPERATIONS = (:predict,
                             :predict_mean,
@@ -184,7 +183,7 @@ const LOSS_FUNCTIONS = vcat(MARGIN_LOSSES, DISTANCE_LOSSES)
 # default_resource allows to switch the mode of parallelization
 
 default_resource()    = DEFAULT_RESOURCE[]
-default_resource(res) = (DEFAULT_RESOURCE[] = res)
+default_resource(res) = (DEFAULT_RESOURCE[] = res;)
 
 # ===================================================================
 # Includes
@@ -300,7 +299,7 @@ export flat_values, recursive_setproperty!,
     recursive_getproperty, pretty, unwind
 
 # show.jl
-export HANDLE_GIVEN_ID, @more, @constant, @bind, color_on, color_off
+export HANDLE_GIVEN_ID, @more, @constant, color_on, color_off
 
 # datasets.jl:
 export load_boston, load_ames, load_iris, load_sunspots,
@@ -312,7 +311,7 @@ export load_boston, load_ames, load_iris, load_sunspots,
 export source, Source, CallableReturning
 
 # machines.jl:
-export machine, Machine, fit!, report, fit_only!
+export machine, Machine, fit!, report, fit_only!, default_scitype_check_level
 
 # datasets_synthetics.jl
 export make_blobs, make_moons, make_circles, make_regression

--- a/src/composition/learning_networks/nodes.jl
+++ b/src/composition/learning_networks/nodes.jl
@@ -249,10 +249,10 @@ function _formula(stream, X::Node, depth, indent)
     n_args = length(X.args)
     if X.machine !== nothing
         print(stream, crind(indent + length(operation_name) - anti))
-        printstyled(IOContext(stream, :color=>SHOW_COLOR),
+        printstyled(IOContext(stream, :color=>SHOW_COLOR[]),
 #                        handle(X.machine),
                         X.machine,
-                        bold=SHOW_COLOR)
+                        bold=SHOW_COLOR[])
         n_args == 0 || print(stream, ", ")
     end
     for k in 1:n_args
@@ -277,7 +277,7 @@ function Base.show(io::IO, ::MIME"text/plain", X::Node)
     print(io, "  formula:\n")
     _formula(io, X, 4)
     # print(io, " ")
-    # printstyled(IOContext(io, :color=>SHOW_COLOR),
+    # printstyled(IOContext(io, :color=>SHOW_COLOR[]),
     #             handle(X),
     #             color=color(X))
 end

--- a/src/init.jl
+++ b/src/init.jl
@@ -1,5 +1,8 @@
 function __init__()
+    global HANDLE_GIVEN_ID = Dict{UInt64,Symbol}()
     global DEFAULT_RESOURCE = Ref{AbstractResource}(CPU1())
+    global DEFAULT_SCITYPE_CHECK_LEVEL = Ref{Int}(1)
+    global SHOW_COLOR = Ref{Bool}(true)
 
     # for testing asynchronous training of learning networks:
     global TESTING = parse(Bool, get(ENV, "TEST_MLJBASE", "false"))

--- a/src/machines.jl
+++ b/src/machines.jl
@@ -106,9 +106,9 @@ err_length_mismatch(model) = DimensionMismatch(
     "Differing number of observations "*
     "in input and target. ")
 
-check(model::Any, args...; kwargs...) =
+check(model::Any, args...) =
     throw(ArgumentError("Expected a `Model` instance, got $model. "))
-function check(model::Model, args...; full=false)
+function check(model::Model, args...)
     nowarns = true
 
     F = fit_data_scitype(model)
@@ -306,7 +306,7 @@ machine(model::Model, arg1::AbstractNode, arg2, args...; kwargs...) =
 
 function machine(model::Model, raw_arg1, raw_args...; kwargs...)
     args = source.((raw_arg1, raw_args...))
-    check(model, args...; full=true)
+    check(model, args...)
     return Machine(model, args...; kwargs...)
 end
 
@@ -555,7 +555,7 @@ function fit_only!(mach::Machine{<:Model,cache_data};
                     @warn "Some learning network source nodes are empty. "
                 @info "Running type checks... "
                 raw_args = map(N -> N(), mach.args)
-                if check(mach.model, source.(raw_args)... ; full=true)
+                if check(mach.model, source.(raw_args)...)
                     @info "Type checks okay. "
                 else
                     @info "It seems an upstream node in a learning "*

--- a/src/machines.jl
+++ b/src/machines.jl
@@ -14,12 +14,12 @@ The effect of the `scitype_check_level` option in calls of the form
 `machine(model, data, scitype_check_level=...)` is summarized below:
 
 `scitype_check_level` | Inspect scitypes? | If `Unknown` in scitypes | If other scitype mismatch |
-|:-----------:|:-----------------:|:------------------------:|:-------------------------:|
-0             | ×                 |                          |                           |
-1 (startup)   | ✓                 |                          | warning                   |
-2             | ✓                 | warning                  | warning                   |
-3             | ✓                 | warning                  | error                     |
-4             | ✓                 | error                    | error                     |
+|:-------------------:|:-----------------:|:------------------------:|:-------------------------:|
+0                     | ×                 |                          |                           |
+1 (value at startup)  | ✓                 |                          | warning                   |
+2                     | ✓                 | warning                  | warning                   |
+3                     | ✓                 | warning                  | error                     |
+4                     | ✓                 | error                    | error                     |
 
 See also [`machine`](@ref)
 

--- a/src/machines.jl
+++ b/src/machines.jl
@@ -222,8 +222,8 @@ is computed, and this is compared with the scitypes expected by the
 model, unless `args` contains `Unknown` scitypes and
 `scitype_check_level < 4`, in which case no further action is
 taken. Whether warnings are issued or errors thrown depends the
-level. The method `default_scitype_check_level`](@ref) controls the
-default level (`1` at startup).
+level. For details, see `default_scitype_check_level`](@ref), a method
+to inspect or change the default level (`1` at startup).
 
 ### Learning network machines
 

--- a/src/machines.jl
+++ b/src/machines.jl
@@ -179,9 +179,8 @@ Specify `cache=false` to prioritize memory management over speed.
 If `check_level > 0` (default is `1`) then the scitype of each `arg`
 in `args` is computed, and this is compared with the scitypes expected
 by the model, unless `args` contains `Unknown` scitypes and
-`check_level < 4`, in which case no further type checks are
-applied. Warnings are issued or errors thrown as detailed in the
-following table:
+`check_level < 4`, in which case no further action is taken. Warnings
+are issued or errors thrown as detailed in the following table:
 
 `check_level` | Inspect scitypes? | If `Unknown` in scitypes | If other scitype mismatch |
 |:-----------:|:-----------------:|:------------------------:|:-------------------------:|

--- a/src/machines.jl
+++ b/src/machines.jl
@@ -6,7 +6,7 @@
 Return the current global default value for scientific type checking
 when constructing machines.
 
-   default_scitype_check_level(i)
+   default_scitype_check_level(i::Integer)
 
 Set the global default value for scientific type checking to `i`.
 

--- a/src/machines.jl
+++ b/src/machines.jl
@@ -118,15 +118,16 @@ function _contains_unknown(F::Type{<:Tuple})
     return any(_contains_unknown, F.parameters)
 end
 
-warn_generic_scitype_mismatch(S, F, T) =
+alert_generic_scitype_mismatch(S, F, T) =
     "The number and/or types of data arguments do not " *
-    "match what the specified model supports.\n"*
-    "Run `@doc $T` to learn more about your model's requirements.\n\n"*
+    "match what the specified model supports. Suppress this "*
+    "type check by specifying `scitype_check_level=0`.\n\n"*
+    "Run `@doc $T` to learn more about your model's requirements.\n"*
     "Commonly, but non exclusively, supervised models are constructed " *
     "using the syntax `machine(model, X, y)` or `machine(model, X, y, w)` " *
-    "while most other models with `machine(model, X)`. " *
+    "while most other models are constructed with `machine(model, X)`. " *
     "Here `X` are features, `y` a target, and `w` sample or class weights.\n\n" *
-    "In general, data in `machine(model, data...)` must satisfy " *
+    "In general, data in `machine(model, data...)` is expected to satisfy " *
     "`scitype(data) <: MLJ.fit_data_scitype(model)`.\n"*
     "In the present case:\n"*
     "scitype(data) = $S\n"*
@@ -160,7 +161,7 @@ function check(model::Model, scitype_check_level, args...)
     S = Tuple{elscitype.(args)...}
     if !(S <: F)
         is_okay = false
-        message = warn_generic_scitype_mismatch(S, F, typeof(model))
+        message = alert_generic_scitype_mismatch(S, F, typeof(model))
         if scitype_check_level >= 3
             throw(ArgumentError(message))
         else
@@ -221,7 +222,8 @@ is computed, and this is compared with the scitypes expected by the
 model, unless `args` contains `Unknown` scitypes and
 `scitype_check_level < 4`, in which case no further action is
 taken. Whether warnings are issued or errors thrown depends the
-level. See [`default_scitype_check_level`](@ref) for details.
+level. The method `default_scitype_check_level`](@ref) controls the
+default level (`1` at startup).
 
 ### Learning network machines
 

--- a/src/machines.jl
+++ b/src/machines.jl
@@ -832,13 +832,10 @@ Returns a shallow copy of the machine to make it serializable. In particular,
 all training data is removed and, if necessary, learned parameters are replaced
 with persistent representations.
 
-<<<<<<< HEAD
-Any general purpose Julia serialization may be applied to the output of
-=======
 Any general purpose Julia serializer may be applied to the output of
->>>>>>> dev
-`serializable` (eg, JLSO, BSON, JLD) but you must call `restore!(mach)` on
-the deserialised object `mach` before using it. See the example below.
+`serializable` (eg, JLSO, BSON, JLD) but you must call
+`restore!(mach)` on the deserialised object `mach` before using
+it. See the example below.
 
 If using Julia's standard Serialization library, a shorter workflow is
 available using the [`save`](@ref) method.

--- a/src/machines.jl
+++ b/src/machines.jl
@@ -94,7 +94,7 @@ warn_generic_scitype_mismatch(S, F, T) =
     "Commonly, but non exclusively, supervised models are constructed " *
     "using the syntax `machine(model, X, y)` or `machine(model, X, y, w)` " *
     "while most other models with `machine(model, X)`. " *
-    "Here `X` are features, `y` a target, and `w` sample or class weights.\n" *
+    "Here `X` are features, `y` a target, and `w` sample or class weights.\n\n" *
     "In general, data in `machine(model, data...)` must satisfy " *
     "`scitype(data) <: MLJ.fit_data_scitype(model)` unless the " *
     "right-hand side contains `Unknown` scitypes.\n"*
@@ -150,7 +150,7 @@ function check(model::Model, check_level, args...)
 end
 
 """
-    machine(model, args...; cache=true)
+    machine(model, args...; cache=true, check_level)
 
 Construct a `Machine` object binding a `model`, storing
 hyper-parameters of some machine learning algorithm, to some data,
@@ -176,11 +176,18 @@ fit!(mach, rows=1:50)
 predict(mach, selectrows(X, 51:100)) # or predict(mach, rows=51:100)
 ```
 
-Specify `cache=false` to prioritize memory management over speed, and
-to guarantee data anonymity when serializing composite models.
+Specify `cache=false` to prioritize memory management over speed.
+
+If `args` contain `Unknown` scientific types, the `machine`
+constructor will not check that the specified `model` explicitly
+supports that type of data, and does so silently by default. Specify
+`check_level >= 2` to be notified in the event of check
+skipping. Specify `check_level=3` if you wish an error to be thrown if
+scientific type mismatches occur. Otherwise a warning only is
+issued.
 
 When building a learning network, `Node` objects can be substituted
-for the concrete data.
+for the concrete data. 
 
 ### Learning network machines
 

--- a/src/machines.jl
+++ b/src/machines.jl
@@ -16,7 +16,7 @@ The effect of the `scitype_check_level` option in calls of the form
 `scitype_check_level` | Inspect scitypes? | If `Unknown` in scitypes | If other scitype mismatch |
 |:-----------:|:-----------------:|:------------------------:|:-------------------------:|
 0             | ×                 |                          |                           |
-1             | ✓                 |                          | warning                   |
+1 (startup)   | ✓                 |                          | warning                   |
 2             | ✓                 | warning                  | warning                   |
 3             | ✓                 | warning                  | error                     |
 4             | ✓                 | error                    | error                     |

--- a/src/machines.jl
+++ b/src/machines.jl
@@ -213,7 +213,7 @@ for the concrete data but no type or dimension checks are applied.
 
 ### Checks on the types of training data
 
-A model articulates it's data requirements using [scientific
+A model articulates its data requirements using [scientific
 types](https://juliaai.github.io/ScientificTypes.jl/dev/), i.e.,
 using the [`scitype`](@ref) function instead of the `typeof` function.
 

--- a/src/measures/measure_search.jl
+++ b/src/measures/measure_search.jl
@@ -15,7 +15,7 @@ function Base.show(stream::IO, p::MeasureProxy)
 end
 
 function Base.show(stream::IO, ::MIME"text/plain", p::MeasureProxy)
-    printstyled(IOContext(stream, :color=> MLJBase.SHOW_COLOR),
+    printstyled(IOContext(stream, :color=> MLJBase.SHOW_COLOR[]),
                 p.docstring, bold=false, color=:magenta)
     println(stream)
     MLJBase.fancy_nt(stream, p)

--- a/src/resampling.jl
+++ b/src/resampling.jl
@@ -540,7 +540,7 @@ function Base.show(io::IO, ::MIME"text/plain", e::PerformanceEvaluation)
             "  per_observation, fitted_params_per_fold,\n"*
             "  report_per_fold, train_test_pairs")
     println(io, "Extract:")
-    show_color = MLJBase.SHOW_COLOR
+    show_color = MLJBase.SHOW_COLOR[]
     color_off()
     PrettyTables.pretty_table(io, data, header;
                               header_crayon=PrettyTables.Crayon(bold=false),

--- a/src/show.jl
+++ b/src/show.jl
@@ -25,6 +25,8 @@ end
 """
     @constant x = value
 
+Private method (used in testing).
+
 Equivalent to `const x = value` but registers the binding thus:
 
     MLJBase.HANDLE_GIVEN_ID[objectid(value)] = :x
@@ -42,17 +44,6 @@ macro constant(ex)
     value = ex.args[2]
     quote
         const $(esc(handle)) = $(esc(value))
-        id = objectid($(esc(handle)))
-        HANDLE_GIVEN_ID[id] = @colon $handle
-        $(esc(handle))
-    end
-end
-macro bind(ex)
-    ex.head == :(=) || throw(error("Expression must be an assignment."))
-    handle = ex.args[1]
-    value = ex.args[2]
-    quote
-        $(esc(handle)) = $(esc(value))
         id = objectid($(esc(handle)))
         HANDLE_GIVEN_ID[id] = @colon $handle
         $(esc(handle))

--- a/src/show.jl
+++ b/src/show.jl
@@ -1,21 +1,19 @@
 ## REGISTERING LABELS OF OBJECTS DURING ASSIGNMENT
 
-const HANDLE_GIVEN_ID = Dict{UInt64,Symbol}()
-SHOW_COLOR = true
 """
     color_on()
 
 Enable color and bold output at the REPL, for enhanced display of MLJ objects.
 
 """
-color_on() = (global SHOW_COLOR=true;)
+color_on() = (SHOW_COLOR[] = true;)
 """
     color_off()
 
 Suppress color and bold output at the REPL for displaying MLJ objects.
 
 """
-color_off() = (global SHOW_COLOR=false;)
+color_off() = (SHOW_COLOR[] = false;)
 
 
 macro colon(p)
@@ -132,7 +130,7 @@ function Base.show(stream::IO, object::MLJType)
     str = simple_repr(typeof(object))
     show_handle(object) && (str *= " $(handle(object))")
     if false # !isempty(propertynames(object))
-        printstyled(IOContext(stream, :color=> SHOW_COLOR),
+        printstyled(IOContext(stream, :color=> SHOW_COLOR[]),
                     str, bold=false, color=:blue)
     else
         print(stream, str)
@@ -183,7 +181,7 @@ function fancy(stream, object::MLJType, current_depth, depth, n)
         print(stream, ")")
         if current_depth == 0 && show_handle(object)
             description = " $(handle(object))"
-            printstyled(IOContext(stream, :color=> SHOW_COLOR),
+            printstyled(IOContext(stream, :color=> SHOW_COLOR[]),
                         description, bold=false, color=:blue)
         end
     end

--- a/src/sources.jl
+++ b/src/sources.jl
@@ -129,7 +129,7 @@ function Base.show(stream::IO, object::AbstractNode)
     str = simple_repr(typeof(object))
     show_handle(object) && (str *= " $(handle(object))")
     if false
-        printstyled(IOContext(stream, :color=> SHOW_COLOR),
+        printstyled(IOContext(stream, :color=> SHOW_COLOR[]),
                     str, bold=false, color=:blue)
     else
         print(stream, str)

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -229,7 +229,7 @@ function pretty(io::IO, X; showtypes=true, alignment=:l, kwargs...)
     else
         header  = (names, )
     end
-    show_color = MLJBase.SHOW_COLOR
+    show_color = MLJBase.SHOW_COLOR[]
     color_off()
     try
         PrettyTables.pretty_table(io, MLJBase.matrix(X),

--- a/test/composition/learning_networks/machines.jl
+++ b/test/composition/learning_networks/machines.jl
@@ -264,7 +264,7 @@ end
     filename = "stack_mach.jls"
     X, y = make_regression(100, 1)
     model = Stack(
-        metalearner = DecisionTreeRegressor(), 
+        metalearner = DecisionTreeRegressor(),
         tree1 = DecisionTreeRegressor(min_samples_split=3),
         tree2 = DecisionTreeRegressor(),
         measures=rmse)
@@ -309,7 +309,7 @@ end
 
     pipe = (X -> coerce(X, :x₁=>Continuous)) |> DecisionTreeRegressor()
     model = Stack(
-        metalearner = DecisionTreeRegressor(), 
+        metalearner = DecisionTreeRegressor(),
         pipe = pipe)
     mach = machine(model, X, y)
     fit!(mach, verbosity=0)
@@ -335,7 +335,7 @@ end
 
 @testset "Test serialized filesize does not increase with datasize" begin
     model = Stack(
-        metalearner = FooBarRegressor(lambda=1.), 
+        metalearner = FooBarRegressor(lambda=1.),
         model_1 = DeterministicConstantRegressor(),
         model_2=ConstantRegressor())
 

--- a/test/composition/learning_networks/nodes.jl
+++ b/test/composition/learning_networks/nodes.jl
@@ -26,7 +26,7 @@ y = 2X.x1  - X.x2 + 0.05*rand(N);
     yhat = predict(mach2, W)
     @test_logs((:error, r"Problem fitting"),
                (:info, r"Running type checks"),
-               (:warn, MLJBase.warn_generic_scitype_mismatch(
+               (:warn, MLJBase.alert_generic_scitype_mismatch(
                    scitype((X, y)),
                    MLJBase.fit_data_scitype(mach2.model),
                    typeof(mach2.model)
@@ -40,7 +40,7 @@ y = 2X.x1  - X.x2 + 0.05*rand(N);
     @test_logs((:error, r"Problem fitting"),
                (:warn, r"^Some learning network source"),
                (:info, r"Running type checks"),
-               (:warn, MLJBase.warn_generic_scitype_mismatch(
+               (:warn, MLJBase.alert_generic_scitype_mismatch(
                    Tuple{Nothing},
                    MLJBase.fit_data_scitype(mach1.model),
                    typeof(mach1.model)

--- a/test/composition/models/pipelines.jl
+++ b/test/composition/models/pipelines.jl
@@ -400,7 +400,7 @@ end
     p.constant_classifier = ConstantRegressor()
     @test_logs((:error, r"^Problem"),
            (:info, r"^Running type"),
-               (:warn, MLJBase.warn_generic_scitype_mismatch(
+               (:warn, MLJBase.alert_generic_scitype_mismatch(
                    scitype((X, y)),
                    MLJBase.fit_data_scitype(ConstantRegressor()),
                    typeof(ConstantRegressor())

--- a/test/machines.jl
+++ b/test/machines.jl
@@ -108,7 +108,7 @@ MLJBase.fit_data_scitype(::Type{<:FooBar}) =
 
 struct FooBarUnknown <: Model end
 
-@testset "machine check_level" begin
+@testset "machine scitype_check_level" begin
 
     X = [1, 2, 3, 4]
     y = rand(4)
@@ -117,42 +117,55 @@ struct FooBarUnknown <: Model end
 
     model = FooBar()
 
-    for check_level in [1, 2]
-        @test_logs machine(model, X, y; check_level)
-        @test_logs machine(model, X; check_level)
+    for scitype_check_level in [1, 2]
+        @test_logs machine(model, X, y; scitype_check_level)
+        @test_logs machine(model, X; scitype_check_level)
         @test_logs((:warn,
                     MLJBase.warn_generic_scitype_mismatch(Tuple{scitype(y)},
                                                           fit_data_scitype(model),
                                                           FooBar)),
-                   machine(model, y; check_level))
+                   machine(model, y; scitype_check_level))
     end
 
-    check_level = 3
-    @test_logs machine(model, X, y; check_level)
-    @test_logs machine(model, X; check_level)
+    scitype_check_level = 3
+    @test_logs machine(model, X, y; scitype_check_level)
+    @test_logs machine(model, X; scitype_check_level)
     @test_throws(ArgumentError(
         MLJBase.warn_generic_scitype_mismatch(Tuple{scitype(y)},
                                               fit_data_scitype(model),
                                               FooBar)),
-                 machine(model, y; check_level))
+                 machine(model, y; scitype_check_level))
+
+    @test default_scitype_check_level() == 1
+    default_scitype_check_level(3)
+    @test default_scitype_check_level() == 3
+
+    @test_logs machine(model, X, y)
+    @test_logs machine(model, X)
+    @test_throws(ArgumentError(
+        MLJBase.warn_generic_scitype_mismatch(Tuple{scitype(y)},
+                                              fit_data_scitype(model),
+                                              FooBar)),
+                 machine(model, y))
+    default_scitype_check_level(1)
 
     # with Unknown scitypes
 
     model = FooBarUnknown()
 
-    check_level = 1
-    @test_logs machine(model, X, y; check_level)
-    @test_logs machine(model, X; check_level)
+    scitype_check_level = 1
+    @test_logs machine(model, X, y; scitype_check_level)
+    @test_logs machine(model, X; scitype_check_level)
 
     warning = MLJBase.WARN_UNKNOWN_SCITYPE
-    for check_level in [2, 3]
-        @test_logs (:warn, warning) machine(model, X, y; check_level)
-        @test_logs (:warn, warning) machine(model, X; check_level)
+    for scitype_check_level in [2, 3]
+        @test_logs (:warn, warning) machine(model, X, y; scitype_check_level)
+        @test_logs (:warn, warning) machine(model, X; scitype_check_level)
     end
 
-    check_level = 4
-    @test_throws ArgumentError(warning) machine(model, X, y; check_level)
-    @test_throws ArgumentError(warning) machine(model, X; check_level)
+    scitype_check_level = 4
+    @test_throws ArgumentError(warning) machine(model, X, y; scitype_check_level)
+    @test_throws ArgumentError(warning) machine(model, X; scitype_check_level)
 
 end
 

--- a/test/machines.jl
+++ b/test/machines.jl
@@ -70,7 +70,7 @@ freeze!(stand)
 
     # supervised model with bad target:
     @test_logs((:warn,
-                MLJBase.warn_generic_scitype_mismatch(
+                MLJBase.alert_generic_scitype_mismatch(
                     Tuple{scitype(X), AbstractVector{Multiclass{N}}},
                     MLJBase.fit_data_scitype(tree),
                     typeof(tree)
@@ -80,7 +80,7 @@ freeze!(stand)
 
     # ordinary transformer:
     @test_logs((:warn,
-                MLJBase.warn_generic_scitype_mismatch(
+                MLJBase.alert_generic_scitype_mismatch(
                     Tuple{scitype(42),},
                     MLJBase.fit_data_scitype(pca),
                     typeof(pca)
@@ -91,7 +91,7 @@ freeze!(stand)
 
     # bad weight vector:
     @test_logs((:warn,
-                MLJBase.warn_generic_scitype_mismatch(
+                MLJBase.alert_generic_scitype_mismatch(
                     Tuple{scitype(X), scitype(y2), scitype(42)},
                     MLJBase.fit_data_scitype(ConstantClassifier()),
                     ConstantClassifier
@@ -121,7 +121,7 @@ struct FooBarUnknown <: Model end
         @test_logs machine(model, X, y; scitype_check_level)
         @test_logs machine(model, X; scitype_check_level)
         @test_logs((:warn,
-                    MLJBase.warn_generic_scitype_mismatch(Tuple{scitype(y)},
+                    MLJBase.alert_generic_scitype_mismatch(Tuple{scitype(y)},
                                                           fit_data_scitype(model),
                                                           FooBar)),
                    machine(model, y; scitype_check_level))
@@ -131,7 +131,7 @@ struct FooBarUnknown <: Model end
     @test_logs machine(model, X, y; scitype_check_level)
     @test_logs machine(model, X; scitype_check_level)
     @test_throws(ArgumentError(
-        MLJBase.warn_generic_scitype_mismatch(Tuple{scitype(y)},
+        MLJBase.alert_generic_scitype_mismatch(Tuple{scitype(y)},
                                               fit_data_scitype(model),
                                               FooBar)),
                  machine(model, y; scitype_check_level))
@@ -143,7 +143,7 @@ struct FooBarUnknown <: Model end
     @test_logs machine(model, X, y)
     @test_logs machine(model, X)
     @test_throws(ArgumentError(
-        MLJBase.warn_generic_scitype_mismatch(Tuple{scitype(y)},
+        MLJBase.alert_generic_scitype_mismatch(Tuple{scitype(y)},
                                               fit_data_scitype(model),
                                               FooBar)),
                  machine(model, y))

--- a/test/machines.jl
+++ b/test/machines.jl
@@ -108,7 +108,7 @@ MLJBase.fit_data_scitype(::Type{<:FooBar}) =
 
 struct FooBarUnknown <: Model end
 
-@testset "machine argument check for generic model" begin
+@testset "machine check_level" begin
 
     X = [1, 2, 3, 4]
     y = rand(4)
@@ -144,10 +144,15 @@ struct FooBarUnknown <: Model end
     @test_logs machine(model, X, y; check_level)
     @test_logs machine(model, X; check_level)
 
+    warning = MLJBase.WARN_UNKNOWN_SCITYPE
     for check_level in [2, 3]
-        @test_logs (:info, MLJBase.INFO_UNKNOWN_SCITYPE) machine(model, X, y; check_level)
-        @test_logs (:info, MLJBase.INFO_UNKNOWN_SCITYPE) machine(model, X; check_level)
+        @test_logs (:warn, warning) machine(model, X, y; check_level)
+        @test_logs (:warn, warning) machine(model, X; check_level)
     end
+
+    check_level = 4
+    @test_throws ArgumentError(warning) machine(model, X, y; check_level)
+    @test_throws ArgumentError(warning) machine(model, X; check_level)
 
 end
 


### PR DESCRIPTION
**edited** (can now modify the global default value of `scitype_check_level` kwarg of `machine` constructor)

Closes https://github.com/alan-turing-institute/MLJ.jl/issues/908 .

Although not breaking, this PR has `for_a-0-point-20-release` as target, not `dev`. This is because it is not urgent and would otherwise have led to messy merge conflicts later on. 

In this PR we:

- (**enhancement**) Allow user to specify `scitype_check_level` when constructing machines, as in `machine(model, X, y, check_scitype_level=2)`, to control how strictly the constructor enforces scitype type compatibility between `model` and the data. Allow user to change the global default `scitype_check_level` using new method `scitype_check_level(i::Int)`. 

From the new docstring:

```
machine(model, args...; cache=true, scitype_check_level=1)
```
...

If `scitype_check_level > 0` (default is `1`) then the scitype of each `arg`
in `args` is computed, and this is compared with the scitypes expected
by the model, unless `args` contains `Unknown` scitypes and
`check_level < 4`, in which case no further action is taken. Warnings
are issued or errors thrown as detailed in the following table:

`check_level` | Inspect scitypes? | If `Unknown` in scitypes | If other scitype mismatch |
|:-----------:|:-----------------:|:------------------------:|:-------------------------:|
0             | ×                 |                          |                           |
1             | ✓                 |                          | warning                   |
2             | ✓                 | warning                  | warning                   |
3             | ✓                 | warning                  | error                     |
4             | ✓                 | error                    | error                     |

 