### PR TITLE
Add interface point for specifying `acceleration` in a composite models

### DIFF
--- a/src/composition/learning_networks/machines.jl
+++ b/src/composition/learning_networks/machines.jl
@@ -35,6 +35,7 @@ function _operation_part(signature)
     ops = filter(in(OPERATIONS), keys(signature))
     return NamedTuple{ops}(map(op->getproperty(signature, op), ops))
 end
+
 function _report_part(signature)
     :report in keys(signature) || return NamedTuple()
     return signature.report
@@ -164,7 +165,7 @@ function check_surrogate_machine(::Union{Unsupervised},
     return nothing
 end
 
-function machine(model::Surrogate, _sources::Source...; pair_itr...)
+function machine(model::Surrogate, _sources::Source...; acceleration=CPU1(), pair_itr...)
 
     # named tuple, such as `(predict=yhat, transform=W)`:
     signature = (; pair_itr...)
@@ -185,7 +186,7 @@ function machine(model::Surrogate, _sources::Source...; pair_itr...)
 
     check_surrogate_machine(model, signature, _sources)
 
-    mach = Machine(model, _sources...)
+    mach = Machine(model, _sources...; acceleration=acceleration)
 
     mach.fitresult = CompositeFitresult(signature)
 
@@ -211,6 +212,7 @@ function machine(_sources::Source...; pair_itr...)
     return machine(model, _sources...; pair_itr...)
 
 end
+
 
 """
     N = glb(mach::Machine{<:Union{Composite,Surrogate}})

--- a/src/composition/learning_networks/machines.jl
+++ b/src/composition/learning_networks/machines.jl
@@ -248,7 +248,7 @@ See also [`machine`](@ref)
 """
 function fit!(mach::Machine{<:Surrogate}; kwargs...)
     glb_node = glb(mach)
-    fit!(glb_node; kwargs...)
+    fit!(glb_node; acceleration=mach.acceleration, kwargs...)
     mach.state += 1
     report_additions_ = _call(_report_part(signature(mach.fitresult)))
     mach.report = merge(report(glb_node), report_additions_)

--- a/src/machines.jl
+++ b/src/machines.jl
@@ -41,7 +41,8 @@ mutable struct Machine{M<:Model,C} <: MLJType
     # cleared by fit!(::Node) calls; put! by `fit_only!(machine, true)` calls:
     fit_okay::Channel{Bool}
 
-    # mode of acceleration to be used when training any downstream machines:
+    # mode of acceleration to be used when training downstream
+    # machines in a `fit!(mach)` call (ignored in `fit_only!(mach)` call):
     acceleration::AbstractResource
 
     function Machine(model::M, args::AbstractNode...;

--- a/test/composition/learning_networks/machines.jl
+++ b/test/composition/learning_networks/machines.jl
@@ -309,7 +309,7 @@ end
 
     pipe = (X -> coerce(X, :x₁=>Continuous)) |> DecisionTreeRegressor()
     model = Stack(
-        metalearner = DecisionTreeRegressor(), 
+        metalearner = DecisionTreeRegressor(),
         pipe = pipe)
     mach = machine(model, X, y)
     fit!(mach, verbosity=0)

--- a/test/composition/models/stacking.jl
+++ b/test/composition/models/stacking.jl
@@ -74,8 +74,9 @@ end
                     resampling=CV(;nfolds=3),
                     models...)
     # Testing attribute access of the stack
-    @test propertynames(mystack) == (:resampling, :metalearner, :constant,
-                                    :decisiontree, :ridge_lambda, :ridge)
+        @test propertynames(mystack) == (:resampling, :metalearner, :measures,
+                                         :acceleration, :constant,
+                                         :decisiontree, :ridge_lambda, :ridge)
 
     @test mystack.decisiontree isa DecisionTreeRegressor
 
@@ -191,7 +192,14 @@ end
     metalearner = DeterministicConstantRegressor()
     resampling = CV()
 
-    MLJBase.DeterministicStack(modelnames, models, metalearner, resampling, nothing)
+    MLJBase.DeterministicStack(
+        modelnames,
+        models,
+        metalearner,
+        resampling,
+        nothing,
+        CPU1()
+    )
 
     # Test input_target_scitypes with non matching target_scitypes
     models = [KNNRegressor()]


### PR DESCRIPTION
This PR:

-  introduces a mechanism for implementing accelerated training of composite models that have been defined by "manually" exporting a learning network
- implements the mechanism for `Stack`s
 
An alternative approach with a different interface point for acceleration is provided by #759 . 

Supposing the composite model struct has `acceleration::AbstractResource` as a hyper-parameter, one simply adds `acceleration=acceleration` in the learning network machine constructor. Here's an example:

```julia
mutable struct MyAverageTwo <: DeterministicComposite
    rgs1 # deterministic regressor
    rgs2 # deterministic regressor
    acceleration::AbstractResource
end

function MLJModelInterface.fit(model::MyAverageTwo, verbosity, X, y)

    X = source(X)
    y = source(y)

    m1 = machine(model.rgs1, X, y)
    y1 = predict(m1, X)

    m2 = machine(model.rgs2, X, y)
    y2 = predict(m2, X)

    yhat = 0.5*y1 + 0.5*y2

    # learning network machine
    mach = machine(Deterministic(), X, y; predict=yhat, acceleration=model.acceleration)

    return!(mach, model, verbosity)

end
```

To support resources other than `CPU1()`, requires  new overloadings of  `fit!(::Node, acceleration; kwargs)` as shown [here](https://github.com/JuliaAI/MLJBase.jl/blob/fe637029266ebaf3c351127a4678c0aefe47a09a/src/composition/learning_networks/nodes.jl#L213) for `CPUThreads`.   In a separate [draft branch](https://github.com/JuliaAI/MLJBase.jl/tree/acceleration-with-composites-and-multithreading), I have done just that, and successfully tested a `Stack`.

TODO:

- [ ] Update documentation (for `fit!(::Node)` and `fit!(:Machine{<:Surrogate}` and `fit!(::Machine)`.
- [ ] Add test that  `acceleration=CPUThreads()` in `Stack` throws expected unsupported acceleration error. 
- [ ] See if integration into @from_network is possible