### PR TITLE
Make running tests via `TestEnv` easier

### DIFF
--- a/test/preliminaries.jl
+++ b/test/preliminaries.jl
@@ -1,0 +1,66 @@
+using MLJBase
+if !MLJBase.TESTING
+    error(
+        "To test MLJBase, the environment variable "*
+        "`TEST_MLJBASE` must be set to `\"true\"`\n"*
+        "You can do this in the REPL with `ENV[\"TEST_MLJBASE\"]=\"true\"`"
+    )
+end
+
+using Distributed
+# Thanks to https://stackoverflow.com/a/70895939/5056635 for the exeflags tip.
+addprocs(; exeflags="--project=$(Base.active_project())")
+
+@info "nprocs() = $(nprocs())"
+@static if VERSION >= v"1.3.0-DEV.573"
+    import .Threads
+    @info "nthreads() = $(Threads.nthreads())"
+else
+    @info "Running julia $(VERSION). Multithreading tests excluded. "
+end
+
+@everywhere begin
+    using MLJModelInterface
+    using MLJBase
+    using Test
+    using CategoricalArrays
+    using Logging
+    using ComputationalResources
+    using StableRNGs
+end
+
+import TypedTables
+using Tables
+
+function include_everywhere(filepath)
+    include(filepath) # Load on Node 1 first, triggering any precompile
+    if nprocs() > 1
+        fullpath = joinpath(@__DIR__, filepath)
+        @sync for p in workers()
+            @async remotecall_wait(include, p, fullpath)
+        end
+    end
+end
+
+include("test_utilities.jl")
+
+# load Models module containing model implementations for testing:
+print("Loading some models for testing...")
+include_everywhere("_models/models.jl")
+print("\r                                           \r")
+
+# enable conditional testing of modules by providing test_args
+# e.g. `Pkg.test("MLJBase", test_args=["misc"])`
+RUN_ALL_TESTS = isempty(ARGS)
+macro conditional_testset(name, expr)
+    name = string(name)
+    esc(quote
+        if RUN_ALL_TESTS || $name in ARGS
+            @testset $name $expr
+        end
+    end)
+end
+
+# To avoid printing `@conditional_testset (macro with 1 method)`
+# when loading this file via `include("test/preliminaries.jl")`.
+nothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,65 +1,19 @@
-using Distributed
-addprocs()
-
-
-using MLJBase
-if !MLJBase.TESTING
-    error(
-        "To test MLJBase, the environment variable "*
-        "`TEST_MLJBASE` must be set to `\"true\"`\n"*
-        "You can do this in the REPL with `ENV[\"TEST_MLJBASE\"]=\"true\"`"
-    )
-end
-
-@info "nprocs() = $(nprocs())"
-@static if VERSION >= v"1.3.0-DEV.573"
-    import .Threads
-    @info "nthreads() = $(Threads.nthreads())"
-else
-    @info "Running julia $(VERSION). Multithreading tests excluded. "
-end
-
-@everywhere begin
-    using MLJModelInterface
-    using MLJBase
-    using Test
-    using CategoricalArrays
-    using Logging
-    using ComputationalResources
-    using StableRNGs
-end
-
-import TypedTables
-using Tables
-
-function include_everywhere(filepath)
-    include(filepath) # Load on Node 1 first, triggering any precompile
-    if nprocs() > 1
-        fullpath = joinpath(@__DIR__, filepath)
-        @sync for p in workers()
-            @async remotecall_wait(include, p, fullpath)
-        end
-    end
-end
-
-include("test_utilities.jl")
-
-# load Models module containing model implementations for testing:
-print("Loading some models for testing...")
-include_everywhere("_models/models.jl")
-print("\r                                           \r")
-
-# enable conditional testing of modules by providing test_args
-# e.g. `Pkg.test("MLJBase", test_args=["misc"])`
-RUN_ALL_TESTS = isempty(ARGS)
-macro conditional_testset(name, expr)
-    name = string(name)
-    esc(quote
-        if RUN_ALL_TESTS || $name in ARGS
-            @testset $name $expr
-        end
-    end)
-end
+# To speed up the development workflow, use `TestEnv`.
+# For example:
+# ```
+# $ julia --project
+#
+# julia> ENV["TEST_MLJBASE"] = "true"
+#
+# julia> using TestEnv; TestEnv.activate()
+#
+# julia> include("test/preliminaries.jl")
+# [...]
+#
+# julia> include("test/resampling.jl")
+# [...]
+# ```
+include("preliminaries.jl")
 
 @conditional_testset "misc" begin
     @test include("utilities.jl")


### PR DESCRIPTION
This PR rewrites `runtests.jl` in such a way that tests can easily be executed via `TestEnv`. This speeds up the development workflow because it allows developers to run only one test file or to run specific parts of the tests by copy-pasting code.

## Demo with time info

```julia
$ julia --project

julia> ENV["TEST_MLJBASE"] = "true"

julia> using TestEnv; TestEnv.activate()

julia> @time include("test/preliminaries.jl");
[ Info: nprocs() = 13
[ Info: nthreads() = 6
 40.846299 seconds (27.93 M allocations: 1.629 GiB, 2.42% gc time, 31.45% compilation time)

julia> @time include("test/resampling.jl");
Test Summary:      | Pass  Total
_actual_operations |   18     18
[...]
186.479425 seconds (413.44 M allocations: 24.754 GiB, 4.05% gc time, 70.04% compilation time)

julia> @time include("test/resampling.jl");
Test Summary:      | Pass  Total
_actual_operations |   18     18
[...]
  8.093617 seconds (20.18 M allocations: 1.258 GiB, 4.48% gc time, 76.16% compilation time)
```