### PR TITLE
Cleanup measures to lower burden for new implementations

### DIFF
--- a/src/measures/continuous.jl
+++ b/src/measures/continuous.jl
@@ -26,14 +26,8 @@ body=
 """,
 scitype=DOC_INFINITE)
 
-call(::MeanAbsoluteError, ŷ::ArrMissing{<:Real}, y::ArrMissing{<:Real}) =
-    abs.(ŷ .- y) |> skipinvalid |> mean
-
-call(::MeanAbsoluteError,
-     ŷ::ArrMissing{<:Real},
-     y::ArrMissing{<:Real},
-     w::Arr{<:Real}) =
-         abs.(ŷ .- y) .* w |> skipinvalid |> mean
+call(::MeanAbsoluteError, ŷ, y) = abs.(ŷ .- y) |> skipinvalid |> mean
+call(::MeanAbsoluteError, ŷ, y, w) = abs.(ŷ .- y) .* w |> skipinvalid |> mean
 
 # ----------------------------------------------------------------
 # RootMeanSquaredError
@@ -59,14 +53,8 @@ body=
 """,
 scitype=DOC_INFINITE)
 
-call(::RootMeanSquaredError, ŷ::ArrMissing{<:Real}, y::ArrMissing{<:Real}) =
-    (y .- ŷ).^2 |> skipinvalid |> mean |> sqrt
-
-call(::RootMeanSquaredError,
-     ŷ::ArrMissing{<:Real},
-     y::ArrMissing{<:Real},
-     w::Arr{<:Real}) =
-         (y .- ŷ).^2 .* w |> skipinvalid |> mean |> sqrt
+call(::RootMeanSquaredError, ŷ, y) = (y .- ŷ).^2 |> skipinvalid |> mean |> sqrt
+call(::RootMeanSquaredError, ŷ, y, w) = (y .- ŷ).^2 .* w |> skipinvalid |> mean |> sqrt
 
 # -------------------------------------------------------------------------
 # R-squared (coefficient of determination)
@@ -86,7 +74,8 @@ const RSQ = RSquared
 @create_docs(RSquared,
 body=
 """
-The R² (also known as R-squared or coefficient of determination) is suitable for interpreting linear regression analysis (Chicco et al., [2021](https://doi.org/10.7717/peerj-cs.623)).
+The R² (also known as R-squared or coefficient of determination) is suitable for
+interpreting linear regression analysis (Chicco et al., [2021](https://doi.org/10.7717/peerj-cs.623)).
 
 Let ``\\overline{y}`` denote the mean of ``y``, then
 
@@ -94,7 +83,7 @@ Let ``\\overline{y}`` denote the mean of ``y``, then
 """,
 scitype=DOC_INFINITE)
 
-function call(::RSquared, ŷ::ArrMissing{<:Real}, y::ArrMissing{<:Real})
+function call(::RSquared, ŷ, y)
     num = (ŷ .- y).^2 |> skipinvalid |> sum
     mean_y = mean(y)
     denom = (mean_y .- y).^2 |> skipinvalid |> sum
@@ -127,7 +116,7 @@ Constructor signature: `LPLoss(p=2)`. Reports
 """,
 scitype=DOC_INFINITE)
 
-single(m::LPLoss, ŷ::Real, y::Real) =  abs(y - ŷ)^(m.p)
+single(m::LPLoss, ŷ, y) =  abs(y - ŷ)^(m.p)
 
 # ----------------------------------------------------------------------------
 # RootMeanSquaredLogError
@@ -153,14 +142,10 @@ n^{-1}∑ᵢ\\log\\left({yᵢ \\over ŷᵢ}\\right)``
 footer="See also [`rmslp1`](@ref).",
 scitype=DOC_INFINITE)
 
-call(::RootMeanSquaredLogError, ŷ::ArrMissing{<:Real}, y::ArrMissing{<:Real}) =
+call(::RootMeanSquaredLogError, ŷ, y) =
     (log.(y) - log.(ŷ)).^2 |> skipinvalid |> mean |> sqrt
-
-call(::RootMeanSquaredLogError,
-      ŷ::ArrMissing{<:Real},
-      y::ArrMissing{<:Real},
-      w::Arr{<:Real}) =
-          (log.(y) - log.(ŷ)).^2 .* w |> skipinvalid |> mean |> sqrt
+call(::RootMeanSquaredLogError, ŷ, y, w) =
+    (log.(y) - log.(ŷ)).^2 .* w |> skipinvalid |> mean |> sqrt
 
 # ---------------------------------------------------------------------------
 #  RootMeanSquaredLogProportionalError
@@ -193,11 +178,11 @@ n^{-1}∑ᵢ\\log\\left({yᵢ + \\text{offset} \\over ŷᵢ + \\text{offset}}\\
 footer="See also [`rmsl`](@ref). ",
 scitype=DOC_INFINITE)
 
-call(m::RMSLP, ŷ::ArrMissing{<:Real}, y::ArrMissing{<:Real}) =
+call(m::RMSLP, ŷ, y) =
     (log.(y .+ m.offset) - log.(ŷ .+ m.offset)).^2 |>
     skipinvalid |> mean |> sqrt
 
-call(m::RMSLP, ŷ::ArrMissing{<:Real}, y::ArrMissing{<:Real}, w::Arr{<:Real}) =
+call(m::RMSLP, ŷ, y, w) =
     (log.(y .+ m.offset) - log.(ŷ .+ m.offset)).^2 .* w |>
     skipinvalid |> mean |> sqrt
 
@@ -234,11 +219,13 @@ of such indices.
 
 """, scitype=DOC_INFINITE)
 
-function call(m::RootMeanSquaredProportionalError,
-               ŷ::ArrMissing{<:Real},
-               y::ArrMissing{T},
-               w::Union{Nothing,Arr{<:Real}}=nothing) where T <: Real
-    ret = zero(T)
+function call(
+    m::RootMeanSquaredProportionalError,
+    ŷ,
+    y,
+    w=nothing,
+    )
+    ret = 0
     count = 0
     @inbounds for i in eachindex(y)
         (isinvalid(y[i]) || isinvalid(ŷ[i])) && continue
@@ -282,11 +269,13 @@ where the sum is over indices such that `abs(yᵢ) > tol` and `m` is the number
 of such indices.
 """, scitype=DOC_INFINITE)
 
-function call(m::MeanAbsoluteProportionalError,
-              ŷ::ArrMissing{<:Real},
-              y::ArrMissing{T},
-              w::Union{Nothing,Arr{<:Real}}=nothing) where T <: Real
-    ret = zero(T)
+function call(
+    m::MeanAbsoluteProportionalError,
+    ŷ,
+    y,
+    w=nothing,
+    )
+    ret = 0
     count = 0
     @inbounds for i in eachindex(y)
         (isinvalid(y[i]) || isinvalid(ŷ[i])) && continue
@@ -323,4 +312,4 @@ const LogCosh = LogCoshLoss
 _softplus(x::T) where T<:Real = x > zero(T) ? x + log1p(exp(-x)) : log1p(exp(x))
 _log_cosh(x::T) where T<:Real = x + _softplus(-2x) - log(convert(T, 2))
 
-single(::LogCoshLoss, ŷ::Real, y::Real) = _log_cosh(ŷ - y)
+single(::LogCoshLoss, ŷ, y) = _log_cosh(ŷ - y)

--- a/src/measures/finite.jl
+++ b/src/measures/finite.jl
@@ -88,7 +88,7 @@ $INVARIANT_LABEL
 """,
 scitype=DOC_FINITE)
 
-function call(m::BACC, ŷm, ym, wm::Union{Nothing,Arr{<:Real}}=nothing)
+function call(m::BACC, ŷm, ym, wm=nothing)
 
     ŷ, y, w = _skipinvalid(ŷm, ym, wm)
 
@@ -142,7 +142,8 @@ function (::Kappa)(cm::ConfusionMatrixObject{C}) where C
     # relative observed agreement - same as accuracy
     p₀ = sum(diag(cm.mat))/sum(cm.mat)
 
-    # probability of agreement due to chance - for each class cᵢ, this would be: (#predicted=cᵢ)/(#instances) x (#observed=cᵢ)/(#instances)
+    # probability of agreement due to chance - for each class cᵢ, this
+    # would be: (#predicted=cᵢ)/(#instances) x (#observed=cᵢ)/(#instances)
     rows_sum = sum!(similar(cm.mat, 1, C), cm.mat) # 1 x C matrix
     cols_sum = sum!(similar(cm.mat, C, 1), cm.mat) # C X 1 matrix
     pₑ = first(rows_sum*cols_sum)/sum(rows_sum)^2

--- a/src/measures/measures.jl
+++ b/src/measures/measures.jl
@@ -102,9 +102,9 @@ end
 
 # See measures/README.md for details
 
-# `robust_single` can accept `missing` observations/predictions and is never overloaded;
-# `single` is overloaded but does not neede to handle missings. This factoring allows us
-# to avoid method ambiguities which are cumbersome to avoid with only one method.
+# `robust_single` can accept `missing` observations/predictions but is never overloaded;
+# `single` is overloaded but does not need to handle missings. This factoring allows us
+# to avoid method ambiguities which are cumbersome to avoid with only one function.
 
 robust_single(args...) = single(args...)
 robust_single(m, ::Missing, ::Missing) = missing

--- a/src/measures/measures.jl
+++ b/src/measures/measures.jl
@@ -244,59 +244,52 @@ include("loss_functions_interface.jl")
 
 # # DEFAULT MEASURES
 
-default_measure(T, S) = nothing
+default_measure(T, S) = _default_measure(T, nonmissingtype(S))
+
+_default_measure(T, S) = nothing
 
 # Deterministic + Continuous / Count ==> RMS
-function default_measure(
+function _default_measure(
     ::Type{<:Deterministic},
-    ::Type{<:Union{Vec{<:Union{Missing,Continuous}},
-    Vec{<:Union{Missing,Count}}}}
+    ::Type{<:Union{Vec{<:Continuous}, Vec{<:Count}}},
 )
    return rms
 end
 
 # Deterministic + Finite ==> Misclassification rate
-function default_measure(
+function _default_measure(
     ::Type{<:Deterministic},
-    ::Type{<:Vec{<:Union{Missing,Finite}}}
+    ::Type{<:Vec{<:Finite}},
 )
     return misclassification_rate
 end
 
-# Probabilistic + Finite ==> log loss
-function default_measure(
+# Probabilistic + Finite / Count ==> log loss
+function _default_measure(
     ::Type{<:Probabilistic},
-    ::Type{<:Vec{<:Union{Missing,Finite}}}
+    ::Type{<:Union{Vec{<:Finite},Vec{<:Count}}},
 )
     return log_loss
 end
 
 # Probabilistic + Continuous ==> Log loss
-function default_measure(
+function _default_measure(
     ::Type{<:Probabilistic},
-    ::Type{<:Vec{<:Union{Missing,Continuous}}}
+    ::Type{<:Vec{<:Continuous}},
 )
     return log_loss
 end
 
-# Probabilistic + Count ==> Log score
-function default_measure(
-    ::Type{<:Probabilistic},
-    ::Type{<:Vec{<:Union{Missing, Count}}}
-)
-    return log_loss
-end
-
-function default_measure(
+function _default_measure(
     ::Type{<:MMI.ProbabilisticDetector},
-    ::Type{<:Vec{<:Union{Missing,OrderedFactor{2}}}}
+    ::Type{<:Vec{<:OrderedFactor{2}}},
 )
     return area_under_curve
 end
 
-function default_measure(
+function _default_measure(
     ::Type{<:MMI.DeterministicDetector},
-    ::Type{<:Vec{<:Union{Missing,OrderedFactor{2}}}}
+    ::Type{<:Vec{<:OrderedFactor{2}}},
 )
     return balanced_accuracy
 end
@@ -305,5 +298,5 @@ end
 default_measure(M::Type{<:Supervised}) = default_measure(M, target_scitype(M))
 default_measure(::M) where M <: Supervised = default_measure(M)
 
-default_measure(M::Type{<:Annotator}) = default_measure(M, target_scitype(M))
+default_measure(M::Type{<:Annotator}) = _default_measure(M, target_scitype(M))
 default_measure(::M) where M <: Annotator = default_measure(M)


### PR DESCRIPTION
**1**. When a new performance measure is added, the methods `MLJBase.single` (single observation) and/or `MLJBase.call` (batch of observations) must be implemented. Some current implementations seem unnecessary specific, with regards to the types of their arguments. When these are relaxed (as in this PR) many type instabilities associated with `Missing` appear. To resolve these ambiguities in a naive way requires adding a lot of code, here and for any new implementations. Instead, this PR introduces a small design change in the way missing values are handled, described below. This greatly simplifies the burden on implementations, as reflected in the diff for the updated file `/src/measures/REAMDE.md`. 

**2**. There is a roughly analogous source of method ambiguities in `default_measure` with a similar resolution provided in this PR but not detailed below. 

I can't think how these changes could be breaking, but as an extra reassurance I will:

- [x] Run MLJTestIntegration.jl tests 

to ensure that at least there are no breakages within the MLJ + model interfaces stack.

### Design changes

At present, `single(::Unaggregated, args...)` needs to work when one of the `args` is `missing`. After this PR, `single` no longer needs to work for `missing` values and the `single` method is instead wrapped in a new function `robust_single` which adds the `missing` value handling. Where `call` fallbacks previously broadcasted over `single`, they now broadcast over `robust_single`. 

Here's the key code replacing a previous naive fallback implementation for `single(m, ::Missing, ::Any)`, etc:

```julia
# `robust_single` can accept `missing` observations/predictions but is never overloaded;
# `single` is overloaded but does not need to handle missings. This factoring allows us
# to avoid method ambiguities which are cumbersome to avoid with only one function.

robust_single(args...) = single(args...)
robust_single(m, ::Missing, ::Missing) = missing
robust_single(m, ::Missing, η) = missing
robust_single(m, η̂, ::Missing) = missing
```