### PR TITLE
Support CategoricalArrays@1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MLJBase"
 uuid = "a7f614a8-145f-11e9-1d2a-a57a1082229d"
 authors = ["Anthony D. Blaom <anthony.blaom@gmail.com>"]
-version = "1.8.2"
+version = "1.8.3"
 
 [deps]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"
@@ -39,7 +39,7 @@ StatisticalMeasures = "a19d573c-0a75-4610-95b3-7071388c7541"
 DefaultMeasuresExt = "StatisticalMeasures"
 
 [compat]
-CategoricalArrays = "0.9, 0.10"
+CategoricalArrays = "0.9, 0.10, 1"
 CategoricalDistributions = "0.1"
 ComputationalResources = "0.3"
 DelimitedFiles = "1"


### PR DESCRIPTION
It seems CompatHelper was disabled by GH due to inactivity.

Edit: It seems Tests didn't run with CategoricalArrays@1

Edit 2: It seems the PR requires new releases of CategoricalDistributions (with https://github.com/JuliaAI/CategoricalDistributions.jl/pull/75) and StatisticalMeasures (with CategoricalArrays@1 support)