### PR TITLE
Remove a name conflict for int and decoder

### DIFF
--- a/src/MLJBase.jl
+++ b/src/MLJBase.jl
@@ -85,7 +85,7 @@ import Missings: levels
 using Missings
 import Distributions
 import CategoricalDistributions
-import CategoricalDistributions: UnivariateFinite, int, decoder
+import CategoricalDistributions: UnivariateFinite
 import Distributions: pdf, logpdf, sampler
 const Dist = Distributions
 


### PR DESCRIPTION
To supress this warning I have seen:

```
[ Info: Precompiling MLJ [add582a8-e3ab-11e8-2d5e-e98b27df1bc7]
WARNING: ignoring conflicting import of CategoricalDistributions.int into MLJBase
WARNING: ignoring conflicting import of CategoricalDistributions.decoder into MLJBase
```