### PR TITLE
Stratify shuffle fix

### DIFF
--- a/src/data/data.jl
+++ b/src/data/data.jl
@@ -136,10 +136,9 @@ julia> (Xtrain, Xtest), (ytrain, ytest) = partition((X, y), 0.8, rng=123, multi=
   used, can be an integer seed. If specified, and `shuffle ===
   nothing` is interpreted as true.
 
-* `stratify=nothing`: if a vector is specified, the partition will
-  match the stratification of the given vector. In that case,
-  `shuffle` should be `true` to avoid any bias that may
-  come from the ordering of the rows.
+* `stratify=nothing`: if a vector is specified, the partition will match the
+  stratification of the given vector. In that case, `shuffle` should be `true` (or an
+  `rng` specified) to avoid any bias that may come from the ordering of the rows.
 
 * `multi=false`: if `true` then `X` is expected to be a `tuple` of
   objects sharing a common length, which are each partitioned
@@ -179,12 +178,7 @@ function partition(X, fractions::Real...;
         shuffle = true
     end
     rows = collect(1:n_rows)
-
-    if shuffle === true
-        shuffle!(rng, rows)
-    elseif stratify !== nothing
-        @warn "When a stratification vector is given, shuffle should be true to avoid bias."
-    end
+    shuffle !== nothing && shuffle && shuffle!(rng, rows)
 
     # determine the partition of `rows`:
     row_partition = _partition(rows, collect(fractions), stratify)

--- a/src/data/data.jl
+++ b/src/data/data.jl
@@ -46,7 +46,7 @@ function _partition(rows, fractions, raw_stratify::AbstractVector)
     uv    = unique(stratify)
     # construct table (n_classes * idx_of_that_class)
     # NOTE use of '===' is important to handle missing.
-    idxs  = [[i for i in rows if stratify[rows[i]] === v] for v in uv]
+    idxs  = [[i for i in eachindex(rows) if stratify[rows[i]] === v] for v in uv]
 
     # number of occurences of each class and proportions
     nidxs = length.(idxs)

--- a/src/data/data.jl
+++ b/src/data/data.jl
@@ -138,7 +138,8 @@ julia> (Xtrain, Xtest), (ytrain, ytest) = partition((X, y), 0.8, rng=123, multi=
 
 * `stratify=nothing`: if a vector is specified, the partition will
   match the stratification of the given vector. In that case,
-  `shuffle` cannot be `false`.
+  `shuffle` should be `true` to avoid any bias that may
+  come from the ordering of the rows.
 
 * `multi=false`: if `true` then `X` is expected to be a `tuple` of
   objects sharing a common length, which are each partitioned
@@ -178,7 +179,12 @@ function partition(X, fractions::Real...;
         shuffle = true
     end
     rows = collect(1:n_rows)
-    shuffle !== nothing && shuffle && shuffle!(rng, rows)
+
+    if shuffle === true
+        shuffle!(rng, rows)
+    elseif stratify !== nothing
+        @warn "When a stratification vector is given, shuffle should be true to avoid bias."
+    end
 
     # determine the partition of `rows`:
     row_partition = _partition(rows, collect(fractions), stratify)

--- a/test/data/data.jl
+++ b/test/data/data.jl
@@ -140,14 +140,8 @@ end
     # Stratification implies we should get exactly 40/10 in Train and 40/10 in Test.
     fraction = 0.5
 
-    # B. Define the scenario: SHUFFLE = TRUE
-    # We create a randomized vector of row indices.
-    # This is what triggers the bug in the original code.
-    rng = MersenneTwister(123)
-    rows_shuffled = shuffle(rng, 1:n_total)
-
     # C. Run the partition
-    (train_idxs, test_idxs) = _partition_stratified_fixed(rows_shuffled, [fraction], y)
+    (train_idxs, test_idxs) = partition(eachindex(y), [fraction], y, shuffle=true)
 
     # D. Verify Results
 

--- a/test/data/data.jl
+++ b/test/data/data.jl
@@ -141,7 +141,7 @@ end
     fraction = 0.5
 
     # C. Run the partition
-    (train_idxs, test_idxs) = partition(eachindex(y), [fraction], y, shuffle=true)
+    (train_idxs, test_idxs) = partition(eachindex(y), fraction, stratify=y, shuffle=true)
 
     # D. Verify Results
 


### PR DESCRIPTION
This fixes a docstring and a bug

1. docstring: if a stratification vector is provided, the user should use `shuffle=true` to avoid bias that may be caused by dataset ordering 
2. double lookup in the case of stratification with vector and with shuffle replacement of

```julia
idxs  = [[i for i in rows if stratify[rows[i]] === v] for v in uv]
```

by

```julia
idxs  = [[i for i in eachindex(rows) if stratify[rows[i]] === v] for v in uv]
```

I'm a bit surprised this wasn't caught by the test suite but added an explicit extra test that specifically that path is correct where it wouldn't have been before.