### PR TITLE
Allow predicates in `unpack` to act on string names instead of symbols

### DIFF
--- a/src/data/data.jl
+++ b/src/data/data.jl
@@ -212,13 +212,14 @@ applied to the column names. Selection from the column names is without replacem
 column except the one with name `:id`.
 
 Predicates may also be formulated with the understanding that column names are strings
-instead of symbols, by specifying `string_names=true`, or by
+instead of symbols, by specifying `string_names=true`.
 
 
 Returns a tuple of tables/vectors with length one greater than the number of supplied
 predicates, with the last component including all previously unselected columns.
 
 ```julia-repl
+using DataFrames
 julia> table = DataFrame(x=[1,2], y=['a', 'b'], z=[10.0, 20.0], w=["A", "B"])
 2×4 DataFrame
  Row │ x      y     z        w
@@ -248,22 +249,26 @@ julia> W  # the column(s) left over
 
 julia> YW, _ = unpack(table, in(["y", "w"]); string_names=true)
 julia> YW
-
+2×2 DataFrame
+ Row │ y     w
+     │ Char  String
+─────┼──────────────
+   1 │ a     A
+   2 │ b     B
 
 ```
 
 
-Whenever a returned table contains a single column, it is converted to
-a vector unless `wrap_singles=true`.
+Whenever a returned table contains a single column, it is converted to a vector unless
+`wrap_singles=true`.
 
-If `coerce_options` are specified then `table` is first replaced
-with `coerce(table, coerce_options)`. See
-[`ScientificTypes.coerce`](@ref) for details.
+If `coerce_options` are specified then `table` is first replaced with `coerce(table,
+coerce_options)`. See [`ScientificTypes.coerce`](@ref) for details.
 
-If `shuffle=true` then the rows of `table` are first shuffled, using
-the global RNG, unless `rng` is specified; if `rng` is an integer, it
-specifies the seed of an automatically generated Mersenne twister. If
-`rng` is specified then `shuffle=true` is implicit.
+If `shuffle=true` then the rows of `table` are first shuffled, using the global RNG,
+unless `rng` is specified; if `rng` is an integer, it specifies the seed of an
+automatically generated Mersenne twister. If `rng` is specified then `shuffle=true` is
+implicit.
 
 """
 function unpack(X, predicates...;
@@ -276,7 +281,7 @@ function unpack(X, predicates...;
     if string_names
         predicates = predicates .∘ string
     end
-    
+
     # add a final predicate to unpack all remaining columns into to
     # the last return value:
     predicates = (predicates..., _ -> true)

--- a/src/data/data.jl
+++ b/src/data/data.jl
@@ -211,10 +211,6 @@ applied to the column names. Selection from the column names is without replacem
 `name::Symbol` of `table`. For example, `=!(:id)` is a predicate for selecting every
 column except the one with name `:id`.
 
-Predicates may also be formulated with the understanding that column names are strings
-instead of symbols, by specifying `string_names=true`.
-
-
 Returns a tuple of tables/vectors with length one greater than the number of supplied
 predicates, with the last component including all previously unselected columns.
 
@@ -246,7 +242,12 @@ julia> W  # the column(s) left over
 2-element Vector{String}:
  "A"
  "B"
+```
 
+Predicates may also be formulated with the understanding that column names are strings
+instead of symbols, by specifying `string_names=true`.
+
+```julia-repl
 julia> YW, _ = unpack(table, in(["y", "w"]); string_names=true)
 julia> YW
 2×2 DataFrame
@@ -255,15 +256,34 @@ julia> YW
 ─────┼──────────────
    1 │ a     A
    2 │ b     B
-
 ```
-
 
 Whenever a returned table contains a single column, it is converted to a vector unless
 `wrap_singles=true`.
 
-If `coerce_options` are specified then `table` is first replaced with `coerce(table,
-coerce_options)`. See [`ScientificTypes.coerce`](@ref) for details.
+If `coerce_options` are specified then the scitype of the referenced columns of `table`
+are first coerced, as shown in the following example:
+
+```julia-repl
+julia> YW, _ = unpack(table, in([:y, :w]); y=OrderedFactor) # or `:y => OrderedFactor`
+julia> YW
+2×2 DataFrame
+ Row │ y     w
+     │ Cat…  String
+─────┼──────────────
+   1 │ a     A
+   2 │ b     B
+
+julia> schema(YW)
+┌───────┬──────────────────┬────────────────────────────────┐
+│ names │ scitypes         │ types                          │
+├───────┼──────────────────┼────────────────────────────────┤
+│ y     │ OrderedFactor{2} │ CategoricalValue{Char, UInt32} │
+│ w     │ Textual          │ String                         │
+└───────┴──────────────────┴────────────────────────────────┘
+```
+
+For more flexible type coercion options see [`ScientificTypes.coerce`](@ref).
 
 If `shuffle=true` then the rows of `table` are first shuffled, using the global RNG,
 unless `rng` is specified; if `rng` is an integer, it specifies the seed of an
@@ -271,12 +291,15 @@ automatically generated Mersenne twister. If `rng` is specified then `shuffle=tr
 implicit.
 
 """
-function unpack(X, predicates...;
-                wrap_singles=false,
-                shuffle=nothing,
-                rng=nothing,
-                string_names=false,
-                pairs...)
+function unpack(
+    X,
+    predicates...;
+    wrap_singles=false,
+    shuffle=nothing,
+    rng=nothing,
+    string_names=false,
+    pairs...,
+    )
 
     if string_names
         predicates = predicates .∘ string

--- a/test/data/data.jl
+++ b/test/data/data.jl
@@ -227,6 +227,15 @@ end
     @test isempty(w)
     @test unpack(small, ==(:x), ==(:y); shuffle=true, rng=StableRNG(66)) ==
         unpack(small, ==(:x), ==(:y); rng=StableRNG(66))
+
+    # string names:
+    x1 = categorical(["Female", "Male", "Female"])
+    x2 = [185, 160, 175]
+    x3 = [10.1, 27.1, 25.7]
+    table = NamedTuple{Symbol.(("Gender", "age (years)", "T / °C"))}((x1, x2, x3))
+    X1X2, X3 = unpack(table, !=("T / °C"), string_names=true)
+    @test X1X2 == selectcols(table, [1, 2])
+    @test X3 == x3
 end
 
 @testset "restrict and corestrict" begin


### PR DESCRIPTION
This PR resolves #1043.

After this PR:

```julia
julia> table = DataFrame(x=[1,2], y=['a', 'b'], z=[10.0, 20.0], w=["A", "B"])
2×4 DataFrame
 Row │ x      y     z        w      
     │ Int64  Char  Float64  String 
─────┼──────────────────────────────
   1 │     1  a        10.0  A
   2 │     2  b        20.0  B

julia> YW, _ = unpack(table, in(["y", "w"]); string_names=true)
julia> YW
2×2 DataFrame
 Row │ y     w      
     │ Char  String 
─────┼──────────────
   1 │ a     A
   2 │ b     B
```